### PR TITLE
Make Content and Controller getting more convenient

### DIFF
--- a/Scripts/Runtime/Content/AbstractContent.cs
+++ b/Scripts/Runtime/Content/AbstractContent.cs
@@ -2,9 +2,17 @@
 
 namespace Anvil.Unity.Content
 {
+    public abstract class AbstractContent<T> : AbstractContent where T : AbstractContentController
+    {
+        public new T Controller
+        {
+            get { return (T)base.Controller; }
+        }
+    }
+
     public abstract class AbstractContent : AbstractAnvilMonoBehaviour
     {
-        internal AbstractContentController ContentController { private get; set; }
+        public AbstractContentController Controller { get; internal set; }
         
         internal bool IsContentDisposing { get; private set; }
 
@@ -16,18 +24,13 @@ namespace Anvil.Unity.Content
             }
             IsContentDisposing = true;
 
-            if (ContentController != null && !ContentController.IsContentControllerDisposing)
+            if (Controller != null && !Controller.IsContentControllerDisposing)
             {
-                ContentController.Dispose();
-                ContentController = null;
+                Controller.Dispose();
+                Controller = null;
             }
             
             base.DisposeSelf();
-        }
-
-        public T GetContentController<T>() where T : AbstractContentController
-        {
-            return (T)ContentController;
         }
 
     }

--- a/Scripts/Runtime/Content/AbstractContentController.cs
+++ b/Scripts/Runtime/Content/AbstractContentController.cs
@@ -4,6 +4,17 @@ using UnityEngine;
 
 namespace Anvil.Unity.Content
 {
+    public abstract class AbstractContentController<T> : AbstractContentController where T : AbstractContent
+    {
+        public new T Content
+        {
+            get { return (T)base.Content; }
+        }
+
+        public AbstractContentController(string contentGroupID, string contentLoadingID)
+            : base(contentGroupID, contentLoadingID) { }
+    }
+
     public abstract class AbstractContentController : AbstractAnvilDisposable
     {
         public event Action OnPlayInComplete;
@@ -16,8 +27,7 @@ namespace Anvil.Unity.Content
         public readonly string ContentGroupID;
         public readonly string ContentLoadingID;
 
-        private AbstractContent m_Content;
-
+        public AbstractContent Content { get; private set; }
         //TODO: Remove later on
         private ResourceRequest m_ResourceRequest;
 
@@ -46,18 +56,13 @@ namespace Anvil.Unity.Content
             OnLoadComplete = null;
             OnClear = null;
 
-            if (m_Content != null && !m_Content.IsContentDisposing)
+            if (Content != null && !Content.IsContentDisposing)
             {
-                m_Content.Dispose();
-                m_Content = null;
+                Content.Dispose();
+                Content = null;
             }
             
             base.DisposeSelf();
-        }
-
-        public T GetContent<T>() where T : AbstractContent
-        {
-            return (T)m_Content;
         }
 
         internal void Load()
@@ -78,8 +83,8 @@ namespace Anvil.Unity.Content
             GameObject instance = (GameObject)GameObject.Instantiate(m_ResourceRequest.asset);
             //TODO: Properly sanitize the name with a Regex via util method
             instance.name = instance.name.Replace("(Clone)", string.Empty);
-            m_Content = instance.GetComponent<AbstractContent>();
-            m_Content.ContentController = this;
+            Content = instance.GetComponent<AbstractContent>();
+            Content.Controller = this;
             
             m_ResourceRequest.completed -= HandleOnResourceLoaded;
             OnLoadComplete?.Invoke();

--- a/Scripts/Runtime/Content/ContentGroup.cs
+++ b/Scripts/Runtime/Content/ContentGroup.cs
@@ -118,7 +118,7 @@ namespace Anvil.Unity.Content
             
             ActiveContentController.InternalInitAfterLoadComplete();
 
-            AbstractContent content = ActiveContentController.GetContent<AbstractContent>();
+            AbstractContent content = ActiveContentController.Content;
             Transform transform = content.transform;
             transform.SetParent(ContentGroupRoot);
             transform.localPosition = Vector3.zero;


### PR DESCRIPTION
 - Added generic versions of `AbstractContent `and `AbstractContentController` that hide the base getter and cast to a subtype
 - Renamed `AbstractContent.ContentController` to Controller

I was just going to add this convenience to Station-X but figured I might as well put it in Anvil itself. It's a bit of an unconventional use of generics but it makes getting reference to `AbstractContent` and `AbstractContentController` cleaner and easier to type.