### PR TITLE
Null checking ContentRoot

### DIFF
--- a/Scripts/Runtime/Content/UnityContentManager.cs
+++ b/Scripts/Runtime/Content/UnityContentManager.cs
@@ -29,6 +29,7 @@ namespace Anvil.Unity.Content
             {
                 Object.Destroy(ContentRoot.gameObject);
             }
+            
             base.DisposeSelf();
         }
 


### PR DESCRIPTION
### PR

Everytime we hit the stop button in the editor and null ref error occurs on shutdown because the `ContentRoot` is already being destroyed by Unity's destruction of the hierarchy. 

This change simply null checks it.

Also moved to `Object` instead of `GameObject` because Rider suggested we do so and who am I to argue.

### Notify

@scratch-games/anvil-pr-notifiers
