### PR TITLE
Emit warning from UnityContentManager when not at the root of hierarchy

### DIFF
--- a/Scripts/Runtime/Content/UnityContentManager.cs
+++ b/Scripts/Runtime/Content/UnityContentManager.cs
@@ -20,7 +20,8 @@ namespace Anvil.Unity.Content
         public UnityContentManager(Transform contentRoot) : base()
         {
             ContentRoot = contentRoot;
-            Object.DontDestroyOnLoad(ContentRoot);
+
+            PreventDestroyOnLoad();
         }
 
         protected override void DisposeSelf()
@@ -42,6 +43,21 @@ namespace Anvil.Unity.Content
         protected override void LogWarning(string message)
         {
             Debug.LogWarning(message);
+        }
+
+        private void PreventDestroyOnLoad()
+        {
+            if (ContentRoot.parent == null)
+            {
+                Object.DontDestroyOnLoad(ContentRoot);
+            }
+            else
+            {
+                LogWarning(
+                    $"This {nameof(UnityContentManager)} may be destroyed on a scene change. ContentRoot: {ContentRoot.name}\n" +
+                    $"The {nameof(ContentRoot)} provided is not at the root of the hierarchy."
+                    );
+            }
         }
     }
 }


### PR DESCRIPTION
### PR
Emit a custom warning message when the `ContentRoot` provided to a `UnityContentManager` is not at the root of Unity's hierarchy.

Calling `Object.DontDestroyOnLoad` on a `GameObject` that isn't at the root of Unity's hierarchy causes the engine to emit a warning and the object isn't marked to prevent it being destroyed during a scene load. This change better communicates the implications of a non-root `ContentRoot` to the developer and adds confidence that this isn't an oversight in the class's implementation.

**Warning Message Example:**
```
This UnityContentManager may be destroyed on a scene change. ContentRoot: GameContent
The ContentRoot provided is not at the root of the hierarchy.
UnityEngine.Debug:LogWarning(Object)
...
```

### Notify

@scratch-games/anvil-pr-notifiers
