### PR TITLE
Misc Bug Fixes

### DIFF
--- a/Scripts/Runtime/Content/UnityContentGroup.cs
+++ b/Scripts/Runtime/Content/UnityContentGroup.cs
@@ -27,7 +27,10 @@ namespace Anvil.Unity.Content
         protected override void DisposeSelf()
         {
             OnLoadComplete -= Self_OnLoadComplete;
-            GameObject.Destroy(ContentGroupRoot.gameObject);
+            if (ContentGroupRoot != null)
+            {
+                Object.Destroy(ContentGroupRoot.gameObject);
+            }
             base.DisposeSelf();
         }
 
@@ -38,7 +41,7 @@ namespace Anvil.Unity.Content
             UnityContentManager contentManger = (UnityContentManager)ContentManager;
 
             GameObject groupRootGO = new GameObject($"[CL - {vo.ID}]");
-            GameObject.DontDestroyOnLoad(groupRootGO);
+            Object.DontDestroyOnLoad(groupRootGO);
             ContentGroupRoot = groupRootGO.transform;
             Transform parent = vo.GameObjectRoot == null
                 ? contentManger.ContentRoot

--- a/Scripts/Runtime/Data/Serialization/TinyJSON/UnityEncoder.cs
+++ b/Scripts/Runtime/Data/Serialization/TinyJSON/UnityEncoder.cs
@@ -11,7 +11,7 @@ namespace Anvil.Unity.Data
     /// </summary>
     public class UnityEncoder : Encoder<ProxyArray, ProxyBoolean, ProxyNumber, ProxyObject, UnityProxyString>
     {
-        protected override void EncodeValue(object value, bool forceTypeHint)
+        protected override void EncodeValue(object value, bool forceTypeHint, bool isRetainAsJSONMember = false)
         {
             if (value is Vector2Int vec2)
             {
@@ -48,7 +48,7 @@ namespace Anvil.Unity.Data
                 return;
             }
 
-            base.EncodeValue(value, forceTypeHint);
+            base.EncodeValue(value, forceTypeHint, isRetainAsJSONMember);
         }
     }
 }


### PR DESCRIPTION
A few misc bug fixes.

### What is the current behaviour?

1. Can't compile due to JSON classes in Unity not following the same API that was changed in an Anvil Core PR a while ago.
2. When exiting play mode, the Unity Content Group throws an error because the GameObject was already destroyed and you're trying to destroy it again.

### What is the new behaviour?

1. Fixed up the API to match the change in the Anvil Core PR
2. Added a simple if check. 

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
