### PR TITLE
Fix UnityLogHandler

### DIFF
--- a/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Anvil.CSharp.Logging;
 using UnityEngine;
 using ILogHandler = Anvil.CSharp.Logging.ILogHandler;
@@ -13,8 +14,16 @@ namespace Anvil.Unity.Logging
     {
         public const uint PRIORITY = ConsoleLogHandler.PRIORITY + 10;
 
-        public void HandleLog(LogLevel level, string message)
+        public void HandleLog(
+            LogLevel level,
+            string message,
+            string callerDerivedTypeName,
+            string callerPath,
+            string callerName,
+            int callerLine)
         {
+            message = $"({Path.GetFileNameWithoutExtension(callerPath)}|{callerName}:{callerLine}) {message}";
+
             switch (level)
             {
                 case LogLevel.Debug:

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3deb04ff6201cfac936cbef9cbf9609705c5f163d48faf43299c8e0d34075547
-size 4608
+oid sha256:ca4941f61cc9705c6b16e14e3f4b7ec9084e95168cfc48763a042ee583df37a3
+size 5120


### PR DESCRIPTION
 - Update `UnityLogHandler` to conform to `ILogHandler`
 - Rebuild Anvil.Unity.Logging.dll

### What is the current behaviour?
 - Unity release builds won't compile. `UnityLogHandler` doesn't conform to the latest `ILogHandler`

### What is the new behaviour?
 - Unity release builds will compile. `UnityLogHandler` updated to match log messaging provided buy `ConsoleLogHandler`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
