### PR TITLE
AbstractAnvilMonoBehaviour - Add logger convenience getter

### DIFF
--- a/Scripts/Runtime/Core/AbstractAnvilMonoBehaviour.cs
+++ b/Scripts/Runtime/Core/AbstractAnvilMonoBehaviour.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Anvil.CSharp.Logging;
 using Anvil.CSharp.Core;
 using UnityEngine;
 
@@ -16,11 +17,22 @@ namespace Anvil.Unity.Core
         /// <inheritdoc cref="IAnvilDisposable.IsDisposed"/>
         /// </summary>
         public bool IsDisposed { get; private set; }
-        
+
         /// <summary>
         /// <inheritdoc cref="IAnvilDisposable.IsDisposing"/>
         /// </summary>
         public bool IsDisposing { get; private set; }
+
+        private Log.Logger? m_Logger;
+        /// <summary>
+        /// Returns a <see cref="Log.Logger"/> for this instance to emit log messages with.
+        /// Lazy instantiated.
+        /// </summary>
+        protected Log.Logger Logger
+        {
+            get => m_Logger ?? (m_Logger = Log.GetLogger(this)).Value;
+            set => m_Logger = value;
+        }
 
         protected virtual void Awake()
         {
@@ -28,7 +40,7 @@ namespace Anvil.Unity.Core
             MonoBehaviourUtil.EnforceEditorExposedFieldReferencesSet(this);
 #endif
         }
-        
+
         /// <summary>
         /// <inheritdoc cref="IDisposable.Dispose"/>
         /// Will early return if <see cref="IsDisposed"/> or <see cref="IsDisposing"/> is true.
@@ -48,23 +60,23 @@ namespace Anvil.Unity.Core
             IsDisposing = false;
             IsDisposed = true;
         }
-        
+
         private void OnDestroy()
         {
             if (IsDisposing || IsDisposed)
             {
                 return;
             }
-            
+
             Dispose();
         }
-        
+
         /// <summary>
         /// Override to implement specific Dispose logic.
         /// </summary>
         protected virtual void DisposeSelf()
         {
-            
+
         }
     }
 }


### PR DESCRIPTION
Add convenience getter to `AbstractAnvilMonoBehaviour`
The same implementation as `AbstractAnvilBase`

<!-- Provide a general summary of proposed changes here -->

### What is the current behaviour?
Developers have to manually create their logger instance.

### What is the new behaviour?
Developers can use the `Logger` getter to lazily create and gain reference to their instance's logger.

### What issues does this resolve?
Sore hands?

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
