### PR TITLE
Fix broken update calls when DomainReload disabled

### DIFF
--- a/Scripts/Runtime/DelayedExecution/UpdateSources/AbstractUnityUpdateSource.cs
+++ b/Scripts/Runtime/DelayedExecution/UpdateSources/AbstractUnityUpdateSource.cs
@@ -51,7 +51,7 @@ namespace Anvil.Unity.DelayedExecution
 #endif
 
             // This usually happens when m_UpdateSourceGameObject or one of its parents
-            // - Is accidentally destroyed by another process desroying GameObjects in the hierary.
+            // - Is accidentally destroyed by another process destroying GameObjects in the hierarchy.
             // - GameObject.DontDestroyOnLoad was not applied to the game object for some reason.
             Logger.Error($"{typeof(T)} was destroyed before its owner {this.GetType()}. Dispose must be called on the owner.");
         }

--- a/Scripts/Runtime/DelayedExecution/UpdateSources/AbstractUnityUpdateSource.cs
+++ b/Scripts/Runtime/DelayedExecution/UpdateSources/AbstractUnityUpdateSource.cs
@@ -8,31 +8,55 @@ namespace Anvil.Unity.DelayedExecution
     /// </summary>
     /// <typeparam name="T">Unity requires a MonoBehaviour for it's Update functions, this generic is of type
     /// <see cref="AbstractUnityUpdateSourceMonoBehaviour"/></typeparam>
-    public abstract class AbstractUnityUpdateSource<T> : AbstractUpdateSource where T:AbstractUnityUpdateSourceMonoBehaviour
+    public abstract class AbstractUnityUpdateSource<T> : AbstractUpdateSource where T : AbstractUnityUpdateSourceMonoBehaviour
     {
         private GameObject m_UpdateSourceGameObject;
-        
+
         protected AbstractUnityUpdateSource()
         {
             m_UpdateSourceGameObject = new GameObject($"[UpdateSource - {typeof(T)}]");
             GameObject.DontDestroyOnLoad(m_UpdateSourceGameObject);
             m_UpdateSourceGameObject.transform.SetParent(UnityUpdateSourceGameObjectManager.UpdateSourceRoot);
+
             T updateSource = m_UpdateSourceGameObject.AddComponent<T>();
             updateSource.SetOnUpdateDispatchFunction(DispatchOnUpdateEvent);
+            updateSource.OnDisposing += UpdateSource_OnDisposing;
         }
 
         protected override void DisposeSelf()
         {
             if (m_UpdateSourceGameObject != null)
             {
+                m_UpdateSourceGameObject.GetComponent<T>().OnDisposing -= UpdateSource_OnDisposing;
                 GameObject.Destroy(m_UpdateSourceGameObject);
                 m_UpdateSourceGameObject = null;
             }
-            
+
             base.DisposeSelf();
         }
+
+        private void UpdateSource_OnDisposing()
+        {
+            // If the game object was disposed as part of Unity exiting play mode
+            // then having the MonoBehaviour version disposed is ok because the rest 
+            // of the application is being torn down anyway.
+#if UNITY_EDITOR
+            if (!UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                // Calling dispose explicitly allows this instance to be removed from 
+                // UpdateHandleSourcesManager. This is important when DomainReload is disabled.
+                Dispose();
+                return;
+            }
+#endif
+
+            // This usually happens when m_UpdateSourceGameObject or one of its parents
+            // - Is accidentally destroyed by another process desroying GameObjects in the hierary.
+            // - GameObject.DontDestroyOnLoad was not applied to the game object for some reason.
+            Logger.Error($"{typeof(T)} was destroyed before its owner {this.GetType()}. Dispose must be called on the owner.");
+        }
     }
-    
+
     /// <summary>
     /// Internal management class for Update Source Game Objects
     /// </summary>
@@ -40,7 +64,7 @@ namespace Anvil.Unity.DelayedExecution
     {
         private const string UPDATE_SOURCES_GAME_OBJECT_NAME = "[UpdateSources]";
         private static Transform s_UpdateSourceRoot;
-        
+
         /// <summary>
         /// Returns the Update Sources root Game Object for parenting purposes.
         /// </summary>

--- a/Scripts/Runtime/DelayedExecution/UpdateSources/AbstractUnityUpdateSourceMonoBehaviour.cs
+++ b/Scripts/Runtime/DelayedExecution/UpdateSources/AbstractUnityUpdateSourceMonoBehaviour.cs
@@ -9,14 +9,23 @@ namespace Anvil.Unity.DelayedExecution
     /// </summary>
     public class AbstractUnityUpdateSourceMonoBehaviour : AbstractAnvilMonoBehaviour
     {
+        /// <summary>
+        /// Dispatches when the <see cref="AbstractUnityUpdateSourceMonoBehaviour"/> is being disposed.
+        /// </summary>
+        internal event Action OnDisposing;
+
         private Action m_OnUpdateDispatchFunction;
 
         protected override void DisposeSelf()
         {
+            OnDisposing?.Invoke();
+            OnDisposing = null;
+
             m_OnUpdateDispatchFunction = null;
+
             base.DisposeSelf();
         }
-        
+
         /// <summary>
         /// Sets the function to call when OnUpdate from this MonoBehaviour is fired.
         /// </summary>


### PR DESCRIPTION
When [DomainReload](https://docs.unity3d.com/Manual/DomainReloading.html) is disabled static values aren't cleared between editor play sessions. The `AbstractUnityUpdateSourceMonoBehaviour` instances were being destroyed by the editor but their `AbstractUnityUpdateSource` owners weren't. Since the `AbstractUnityUpdateSource` weren't being disposed they weren't being unregistered from `UpdateHandleSourcesManager` and were delivered during the next play session without their MonoBehaviour counterpart to hook into and pump update events.

**Fix:**
 - Add `AbstractUnityUpdateSourceMonoBehaviour.OnDisposing` event
 - `AbstractUnityUpdateSource` detects `AbstractUnityUpdateSourceMonoBehaviour` and disposes self in editor if currently exiting play mode and wasn't already being disposed.
    - If not in play mode an error is logged because it's a problem if `AbstractUnityUpdateSourceMonoBehaviour`'s are getting destroyed without going through `AbstractUnityUpdateSource.Dispose()`

### What is the current behaviour?
Unity update sources will fail to dispatch update events when the editor is played without a domain reload occurring.
**When domain reload is enabled** it is reloaded between every play session and there is no issue.
**When domain reload is disabled** it is only reloaded if the editor has recompiled.

### What is the new behaviour?
The update sources dispatch an event that they're being disposed. If the editor is currently exiting play mode the `AbstractUnityUpdateSource` will dispose itself as well which, in turn, unregisters the instance from `UpdateHandleSourcesManager`.

`AbstractUnityUpdateSource` will now also log an error when its `MonoBehaviour` counterpart is disposed when the editor isn't exiting play mode and it's not initiated by the `AbstractUnityUpdateSource`. This acts as an assert against an unexpected state and will help developers track down incorrect behaviour if the `AbstractUnityUpdateSourceMonoBehaviour` gets destroyed accidentally.

### What issues does this resolve?
The update system does not work consistently when Domain Reload is disabled.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
