### PR TITLE
Feature - Add UnityLogListener

### DIFF
--- a/Scripts/Runtime/Logging/.CSProject/Anvil.Unity.Logging.csproj
+++ b/Scripts/Runtime/Logging/.CSProject/Anvil.Unity.Logging.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnityLogHandler.cs" />
+    <Compile Include="UnityLogListener.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
@@ -7,7 +7,7 @@ using ILogHandler = Anvil.CSharp.Logging.ILogHandler;
 namespace Anvil.Unity.Logging
 {
     /// <summary>
-    /// Forwards logs to UnityEngine.Debug.
+    /// Forwards logs from <see cref="Log"/> to <see cref="Debug"/>.
     /// </summary>
     [DefaultLogHandler(PRIORITY)]
     public class UnityLogHandler : ILogHandler

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -5,6 +5,10 @@ using StackFrame = System.Diagnostics.StackFrame;
 
 namespace Anvil.Unity.Logging
 {
+    /// <summary>
+    /// An implementation of <see cref="ILogListener"/> for the Unity <see cref="Debug"/> logger.
+    /// Captures all logging made through <see cref="Debug"/> and redirects them through a <see cref="Log.Logger"/>.
+    /// </summary>
     [DefaultLogListener]
     public sealed class UnityLogListener : ILogListener, UnityEngine.ILogHandler
     {

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -1,0 +1,99 @@
+using System;
+using Anvil.CSharp.Logging;
+using UnityEngine;
+using StackFrame = System.Diagnostics.StackFrame;
+
+namespace Anvil.Unity.Logging
+{
+    [DefaultLogListener]
+    public class UnityLogListener : ILogListener, UnityEngine.ILogHandler
+    {
+        private static UnityLogListener s_Instance;
+
+        // With the Burst compiler, it's common to disable the Domain Reload step when entering play mode to increase iteration time.
+        // https://docs.unity3d.com/Packages/com.unity.entities@0.17/manual/install_setup.html
+        // Because of this, statics will preserve state across play sessions.
+        // `RuntimeInitializeOnLoadMethod` ensures we reset the state on every play session.
+        // `RuntimeInitializeLoadType.SubsystemRegistration` represents the earliest moment of all the entries in the enum.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            s_Instance = null;
+        }
+
+        // The log handler in place before this listener initialized.
+        // Called when a log comes through that this listener has already handled.
+        private readonly UnityEngine.ILogHandler m_ExistingLogHandler;
+
+        public UnityLogListener()
+        {
+            Debug.Assert(s_Instance == null, $"There can only be one instance of the {nameof(UnityLogListener)} and it has already been initialized.");
+            s_Instance = this;
+
+            m_ExistingLogHandler = Debug.unityLogger.logHandler;
+            Debug.unityLogger.logHandler = this;
+        }
+
+        /// <inheritdoc />
+        public void LogFormat(LogType logType, UnityEngine.Object context, string format, params object[] args)
+        {
+            // Bypass redirecting unity log messages to logger if logger is already handling the log.
+            // This happens when UnityLogHandler is being used.
+            if (Log.IsHandlingLog)
+            {
+                m_ExistingLogHandler.LogFormat(logType, context, format, args);
+                return;
+            }
+
+            StackFrame stackFrame = GetLogCallerStackFrame();
+            object loggerContext = ResolveLogContext(context, stackFrame);
+            Log.GetLogger(loggerContext).AtLevel(LogTypeToLogLevel(logType), string.Format(format, args), stackFrame.GetFileName(), stackFrame.GetMethod().Name, stackFrame.GetFileLineNumber());
+        }
+
+        /// <inheritdoc />
+        public void LogException(Exception exception, UnityEngine.Object context)
+        {
+            // Bypass redirecting unity log messages to logger if logger is already handling the log.
+            // This happens when UnityLogHandler is being used.
+            if (Log.IsHandlingLog)
+            {
+                m_ExistingLogHandler.LogException(exception, context);
+                return;
+            }
+
+            StackFrame stackFrame = GetLogCallerStackFrame();
+            object loggerContext = ResolveLogContext(context, stackFrame);
+            Log.GetLogger(loggerContext).Error(exception.ToString(), stackFrame.GetFileName(), stackFrame.GetMethod().Name, stackFrame.GetFileLineNumber());
+        }
+
+        private StackFrame GetLogCallerStackFrame()
+        {
+            return new StackFrame(4, true);
+        }
+
+        private object ResolveLogContext(UnityEngine.Object unityContext, StackFrame stackFrame)
+        {
+            return unityContext == null ? stackFrame.GetMethod().ReflectedType : (object)unityContext;
+        }
+
+        private LogLevel LogTypeToLogLevel(LogType logType)
+        {
+            switch (logType)
+            {
+                case LogType.Assert:
+                case LogType.Exception:
+                case LogType.Error:
+                    return LogLevel.Error;
+
+                case LogType.Warning:
+                    return LogLevel.Warning;
+
+                case LogType.Log:
+                    return LogLevel.Debug;
+
+                default:
+                    throw new ArgumentException("Unknown log type: " + logType);
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ca4941f61cc9705c6b16e14e3f4b7ec9084e95168cfc48763a042ee583df37a3
-size 5120
+oid sha256:4f83b74eaa515d477508169088c57aa91baabfcd4c1e48b12f01718c0326d94d
+size 6656

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f83b74eaa515d477508169088c57aa91baabfcd4c1e48b12f01718c0326d94d
+oid sha256:c3bc26bfc1aa9bc9014fdd2ba988c756b2f1efa0040d93a78fa0c11a97f02b7a
 size 6656


### PR DESCRIPTION
Implementation of an `ILogListener` for the Unity logger.
Captures all logs emitted through `Debug.Log,Warn, Error,Assert, etc...` and redirects them through a Logger instance with a best effort made to select the original caller.

With this enabled setting Unity's console to single line is very viable. Now that caller context is included in the log message itself.

### What is the current behaviour?
`Debug.Log, Warn, Error, Assert, etc...` calls do not pass through the `Log` system.

### What is the new behaviour?
By default, `UnityLogListener` will be instantiated and direct all built in logging messages at runtime through `Log`. No developer interaction required. Just update to include these changes.

### What issues does this resolve?
See issues resolved in https://github.com/decline-cookies/anvil-csharp-core/pull/80
Specifically, ECS has some false flag warnings during a valid operation that I wanted to suppress. While manipulating `Debug.unityLogger.logEnabled` would have worked this (combined with the link above) is a more comprehensive solution.

### What PRs does this depend on?
 - https://github.com/decline-cookies/anvil-csharp-core/pull/80

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No - Unless you really don't want debug messages sent through Log.
