### PR TITLE
Logging - Ensure early init, workaround Unity.Debug

### DIFF
--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3bc26bfc1aa9bc9014fdd2ba988c756b2f1efa0040d93a78fa0c11a97f02b7a
+oid sha256:1172fd04937d55f47343f556d1aa8d9524d22f10efa05d17e6365a0db168eab2
 size 6656


### PR DESCRIPTION
 - Add call to `Log` during subsystem registration phase to make sure the listener gets initialized ASAP
 - Add workaround for surprise new logger that Unity has in the works. Currently `Unity.Entities@v0.17` has a `Unity.Debug` static class that proxies logger calls until the new logger is rolled out. Unity source Comment:
``` csharp
    // TODO: provide an implementation of Unity.Debug that does not rely on UnityEngine and modernizes this API
    // (for now it's just here for easier compatibility and fwd migration)
```

### What is the current behaviour?
 - `UnityLogListener`'s initialization is not necessarily initialized ahead of Unity code. The listener is initialized when `Log` is first touched. This could result in missed log messages.
 - Originating caller is incorrectly determined when `Unity.Debug` is used to emit logs. (not to be confused with `UnityEngine.Debug`)

### What is the new behaviour?
 - `UnityLogListener` touches `Log` during subsystem registration to make sure it is initialized ASAP.
 - `UnityLogListener` checks the `StackFrame` to see whether it is referencing a `Unity.Debug` call. If true, a new `StackFrame` on level deeper is used.

### What issues does this resolve?
 - Potentially missed log messages at the start of application execution
 - Incorrect caller context listed when `Unity.Debug` is used.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
