### PR TITLE
UnityLogListener - Fix exception when context resolves to null

### DIFF
--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1172fd04937d55f47343f556d1aa8d9524d22f10efa05d17e6365a0db168eab2
-size 6656
+oid sha256:968afd11ecced1988f4a13d493403666adf25cf790cc8318d937c1d9eb50a803
+size 7168


### PR DESCRIPTION
In some circumstances `stackframe.GetMethod()` returns `null`. We now guard against that scenario. 

### What is the current behaviour?
The `UnityLogListener` will throw an exception when the targeted `StackFrame` can't determine the calling method.
There are a number of edge cases where this can happen but this was discovered when updating to Unity.Entities@0.50 from code that was throwing exceptions from within the entities package.

Further reading indicates that there are many scenarios where `GetMethod()` will return null:
 - https://stackoverflow.com/a/21564897/640196
 - https://github.com/dotnet/runtime/issues/31412

### What is the new behaviour?
When this happens we can't resolve the context so we set the context to the private `UnknownContext` type. At runtime the name of this context just resolves to an empty string.

### What issues does this resolve?
This exception:
```
Invalid exception thrown from custom Anvil.Unity.Logging.UnityLogListener.LogException(). Message: System.NullReferenceException: Object reference not set to an instance of an object
  at Anvil.Unity.Logging.UnityLogListener.SendToLogger (UnityEngine.Object context, Anvil.CSharp.Logging.LogLevel logLevel, System.String message) [0x0005b] in /Users/mbaker/Projects/twisted-dots/build/TwistedDOTS/Assets/Anvil/unity/anvil-unity-core/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs:96 
  at Anvil.Unity.Logging.UnityLogListener.LogException (System.Exception exception, UnityEngine.Object context) [0x0001b] in /Users/mbaker/Projects/twisted-dots/build/TwistedDOTS/Assets/Anvil/unity/anvil-unity-core/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs:74 
  at UnityEngine.Logger.LogException (System.Exception exception, UnityEngine.Object context) [0x0000b] in /Users/bokken/buildslave/unity/build/Runtime/Export/Logging/Logger.cs:132 
  at UnityEngine.Debug.CallOverridenDebugHandler (System.Exception exception, UnityEngine.Object obj) [0x0001e] in /Users/bokken/buildslave/unity/build/Runtime/Export/Debug/Debug.bindings.cs:262 : Null
UnityEngine.Debug:CallOverridenDebugHandler (System.Exception,UnityEngine.Object)
```

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
