### PR TITLE
UnityLogListener - Fix logs from a burst compiled context

### DIFF
--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -234,7 +234,7 @@ namespace Anvil.Unity.Logging
             //       - UnityLogHandler.HandleLog
             //        - Debug.Log
             //         - UnityLogListener.LogFormat - Do nothing because m_IsHandlingBurstedLog = true
-            //  - Someting external (BurstCompilerService.Log?) emits the log to the Unity console
+            //  - Something external (BurstCompilerService.Log?) emits the log to the Unity console
             //      
             // From a Log.Logger instance
             //  - Log.Logger.Debug
@@ -247,9 +247,6 @@ namespace Anvil.Unity.Logging
             //         - UnityLogListener.Application_logMessageReceivedThreaded - Do nothing because Log.IsHandling == true
             //        - m_ExistingLogHandler emits log to the Unity console
             m_PendingLogs.Enqueue(new LogMessage(condition, LogTypeToLogLevel(type), true));
-            //m_IsHandlingBurstedLog = true;
-            //SendToLogger(null, LogTypeToLogLevel(type), condition);
-            //m_IsHandlingBurstedLog = false;
         }
 
         private void PendingLogPump_OnProcessPendingLogs()

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Anvil.CSharp.Logging;
 using UnityEngine;
 using StackFrame = System.Diagnostics.StackFrame;
+using System.Collections.Concurrent;
 
 namespace Anvil.Unity.Logging
 {
@@ -17,6 +18,30 @@ namespace Anvil.Unity.Logging
         /// The context delivered when a context can't be resolved
         /// </summary>
         private sealed class UnknownContext { }
+
+        private readonly struct LogMessage
+        {
+            public readonly string Message;
+            public readonly LogLevel LogLevel;
+            public readonly bool IsFromBurstedContext;
+
+            public LogMessage(string message, LogLevel logLevel, bool isFromBurstedContext)
+            {
+                Message = message;
+                LogLevel = logLevel;
+                IsFromBurstedContext = isFromBurstedContext;
+            }
+        }
+
+        private class LateUpdatePump : MonoBehaviour
+        {
+            public event Action OnLateUpdate;
+
+            private void LateUpdate()
+            {
+                OnLateUpdate?.Invoke();
+            }
+        }
 
         private static UnityLogListener s_Instance;
 
@@ -33,17 +58,46 @@ namespace Anvil.Unity.Logging
             Log.GetStaticLogger(typeof(UnityLogListener));
         }
 
+        private readonly ConcurrentQueue<LogMessage> m_PendingLogs;
+
         // The log handler in place before this listener initialized.
         // Called when a log comes through that this listener has already handled.
         private readonly UnityEngine.ILogHandler m_ExistingLogHandler;
+
+        // true when this listener is handling a log from Burst compiled code.
+        // Must be specially handled because log calls from Burst compiled code don't pass
+        // through the Debug.unityLogger.logHandler. This prevents us from blocking
+        // the default message from being emitted to Unity's console.
+        //
+        // We still want log calls from Burst compiled code to pass through the Log
+        // system so that non-unity handlers may handle the message.
+        //
+        // So, we prevent our decorated log message from emitting to the console
+        // using this flag.
+        //  - The Log system gets a chance to handle log messages from burst compiled code
+        //  - The consumer only sees one message posted to Unity's console.
+        //
+        // win-win...
+        //  Except the poor developers that have to maintain this disaster and adapt it when
+        //  Unity inevitably improves logging within a Burst context.
+        private bool m_IsHandlingBurstedLog = false;
+
 
         public UnityLogListener()
         {
             Debug.Assert(s_Instance == null, $"There can only be one instance of the {nameof(UnityLogListener)} and it has already been initialized.");
             s_Instance = this;
 
+            m_PendingLogs = new ConcurrentQueue<LogMessage>();
+
             m_ExistingLogHandler = Debug.unityLogger.logHandler;
             Debug.unityLogger.logHandler = this;
+
+            Application.logMessageReceivedThreaded += Application_logMessageReceivedThreaded;
+
+            GameObject lateUpdatePumpGO = new GameObject($"{nameof(UnityLogListener)}_{nameof(lateUpdatePumpGO)}");
+            lateUpdatePumpGO.AddComponent<LateUpdatePump>().OnLateUpdate += LateUpdatePump_OnLateUpdate;
+            lateUpdatePumpGO.hideFlags = HideFlags.DontSave|HideFlags.HideInHierarchy;
         }
 
         /// <inheritdoc />
@@ -53,6 +107,14 @@ namespace Anvil.Unity.Logging
             // This happens when UnityLogHandler is being used.
             if (Log.IsHandlingLog)
             {
+                // If this is a log call from Burst compiled code then skip emitting
+                // to Unity's console. Log calls from Burst compiled code don't pass
+                // through Debug.unityLogger.logHandler.
+                if (m_IsHandlingBurstedLog)
+                {
+                    return;
+                }
+                
                 m_ExistingLogHandler.LogFormat(logType, context, format, args);
                 return;
             }
@@ -67,11 +129,85 @@ namespace Anvil.Unity.Logging
             // This happens when UnityLogHandler is being used.
             if (Log.IsHandlingLog)
             {
+                // If this is a log call from Burst compiled code then skip emitting
+                // to Unity's console. Log calls from Burst compiled code don't pass
+                // through Debug.unityLogger.logHandler.
+                if (m_IsHandlingBurstedLog)
+                {
+                    return;
+                }
+
                 m_ExistingLogHandler.LogException(exception, context);
                 return;
             }
 
             SendToLogger(context, LogLevel.Error, exception.ToString());
+        }
+
+        private void Application_logMessageReceivedThreaded(string condition, string stackTrace, LogType type)
+        {
+            if (Log.IsHandlingLog)
+            {
+                return;
+            }
+
+            // Only Burst messages will ever get this far because Unity's default log handler (m_ExistingLogHandler)
+            // is the code responsible for dispatching the logMessageReceived(+Threaded) event.
+            // So the flows are:
+            //
+            // From non-burst
+            //  - Debug.Log
+            //   - UnityLogListener.LogFormat
+            //    - UnityLogListener.SendToLogger - because Log.IsHandlingLog == false
+            //     - Log.DispatchLog - set Log.IsHandlingLog = true
+            //      - UnityLogHandler.HandleLog
+            //       - Debug.Log
+            //        - UnityLogListener.LogFormat
+            //         - m_ExistingLogHandler.LogFormat - because Log.IsHandlingLog == true
+            //          - Application.logMessageReceived(+Threaded)
+            //           - UnityLogListener.Application_logMessageReceivedThreaded - Do nothing because Log.IsHandling == true
+            //          - m_ExistingLogHandler emits log to the Unity console
+            //
+            // From burst
+            //  - Debug.Log
+            //   - Application.logMessageReceived(+Threaded)
+            //    - UnityLogListener.Application_logMessageReceivedThreaded - set m_IsHandlingBurstedLog = true
+            //     - UnityLogListener.SendToLogger - because Log.IsHandlingLog == false
+            //      - Log.DispatchLog - set Log.IsHandlingLog = true
+            //       - UnityLogHandler.HandleLog
+            //        - Debug.Log
+            //         - UnityLogListener.LogFormat - Do nothing because m_IsHandlingBurstedLog = true
+            //  - Someting external (BurstCompilerService.Log?) emits the log to the Unity console
+            //      
+            // From a Log.Logger instance
+            //  - Log.Logger.Debug
+            //   - Log.DispatchLog - set Log.IsHandlingLog = true
+            //    - UnityLogHandler.HandleLog
+            //     - Debug.Log
+            //      - UnityLogListener.LogFormat
+            //       - m_ExistingLogHandler.LogFormat - because Log.IsHandlingLog == true
+            //        - Application.logMessageReceived(+Threaded)
+            //         - UnityLogListener.Application_logMessageReceivedThreaded - Do nothing because Log.IsHandling == true
+            //        - m_ExistingLogHandler emits log to the Unity console
+            m_PendingLogs.Enqueue(new LogMessage(condition, LogTypeToLogLevel(type), true));
+            //m_IsHandlingBurstedLog = true;
+            //SendToLogger(null, LogTypeToLogLevel(type), condition);
+            //m_IsHandlingBurstedLog = false;
+        }
+
+        private void LateUpdatePump_OnLateUpdate()
+        {
+            ProcessPendingLogs();
+        }
+
+        private void ProcessPendingLogs()
+        {
+            while(m_PendingLogs.TryDequeue(out LogMessage message))
+            {
+                m_IsHandlingBurstedLog = message.IsFromBurstedContext;
+                SendToLogger(null, message.LogLevel, message.Message);
+            }
+            m_IsHandlingBurstedLog = false;
         }
 
         private void SendToLogger(UnityEngine.Object context, LogLevel logLevel, string message)

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -81,11 +81,6 @@ namespace Anvil.Unity.Logging
                 OnProcessPendingLogs?.Invoke();
             }
 
-            private void OnGUI()
-            {
-                OnProcessPendingLogs?.Invoke();
-            }
-
             private IEnumerator RunEndOfFrameRoutine()
             {
                 while (true)

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:70369a4b52af61a8499b424f1a0e63dd96d7fec2c8d88ad961184ccd2495c183
-size 10240
+oid sha256:a30793fd1aff184dcf1329a4f99684a0b65c8dc83759f3774214a6403dc509c3
+size 10752

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:968afd11ecced1988f4a13d493403666adf25cf790cc8318d937c1d9eb50a803
-size 7168
+oid sha256:92d11000adf6088ba5391807d103542d68c1efd84b4f9a354c7a7e355408b321
+size 8704

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92d11000adf6088ba5391807d103542d68c1efd84b4f9a354c7a7e355408b321
-size 8704
+oid sha256:70369a4b52af61a8499b424f1a0e63dd96d7fec2c8d88ad961184ccd2495c183
+size 10240


### PR DESCRIPTION
Log messages emitted from bust compiled code are now caught by `UnityLogListener` and piped through the `Log` system.

#### Tag Alongs
**ExcludeAttribute** - Add Attribute which may be placed on methods to exclude them when attempting to resolve the context of a log message caller. This is used to support more robust caller resolution and allow specialized loggers to be less careful about internal stack depth before triggering the `UnityLogListener`.

### What is the current behaviour?
`UnityLogListener` does not receive events emitted from Burst compiled code. This is because logs from burst compiled code do not go through the `Unity.unityLogger` which is where the `UnityLogListener` injects itself to observe logs.

As a result our log handlers would never get a chance to see/handle the messages.
This is unfortunate because the only way to emit logs is through `Debug.Log`
(and soon `BurstableLogger` but that's a different PR)

### What is the new behaviour?
Luckily logs from burst compiled code do trigger `Application.logMessageReceivedThreaded` which the `UnityLogListener` now listens to.

This event triggers on whatever thread the log is emitted so the message must be marshalled back to the main thread. This is done by adding the message to a `ConcurrentQueue` for main thread processing. Pending log messages in the queue are processed as often as possible using the various `MonoBehaviour` life-cycle events (`OnUpdate`, `OnPreRender`, etc...). This does mean that the order of log messages between the Unity Editor Console and a `ILogHandler` (Ex: `FileLogHandler) may not be quite the same. However, developers shouldn't be expecting exact ordering when reading logs emitted from multi-threadded code anyway.

Unfortunately, there is currently no way to prevent the log message emitted by burst from appearing in the Editor console window ([Discussion](https://forum.unity.com/threads/is-it-possible-to-disable-debug-log-in-burst-compiled-code.1280819/)). To avoid doubling up logging messages `UnityLogListener` sets a flag when processing pending events so that it does not post the `Log` system decorated message to the console when the message comes back around.
Normal flow (simplified) is `Debug.Log -> UnityLogListener -> Log -> UnityLogHandler -> Deubg.Log -> UnityLogListener`.

The flow is a lot to take in but it has been documented in detail in `UnityLogListener.Application_logMessageReceivedThreaded`.

#### ExcludeAttribute
When resolving the caller before sending the message off to `Log` the logic now walks up the stack until a method without `Exclude` attribute is found.

### What issues does this resolve?
Logs emitted from burst compiled code are now piped through the `Log` system and decorated for all handlers except `UnityLogHandler`

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
