### PR TITLE
README - Document common git-LFS error

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ This is the recommended Unity project folder structure:
   - Anvil
     - anvil-csharp-core
     - anvil-unity-core
+
+# Common Errors
+## Can't Compile - Errors related to Logging or Logging DLLs are recognized as "Native"
+> Example: `The type or namespace name 'ILogHandler' could not be found`
+This usually means that Git LFS hasn't been initialized. Check the size of the DLL. if it's less than a kilobyte then the Git LFS files have not yet been resolved.
+Running `git lfs pull` in each submodules will generally fix the issue.


### PR DESCRIPTION
Document a common pitfall when initially setting up the library as a submodule...forgetting to init LFS.

### What is the current behaviour?
Forgetting to init LFS causes Unity to interpret the LFS pointer files as native plugins rather than managed Dlls. The developer ends up seeing errors related to definitions in Dlls missing (Ex: `Log`).

### What is the new behaviour?
README now documents the symptoms of the issue and how to fix it.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
