### PR TITLE
Hotfix suppress LINQ warnings

### DIFF
--- a/Scripts/Editor/Logging/LogProjectUtils.cs
+++ b/Scripts/Editor/Logging/LogProjectUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -32,6 +33,7 @@ namespace Anvil.Unity.Logging
         private static readonly string UNITY_SOLUTION_PATH;
         private static readonly string UNITY_CORE_ASSEMBLY_PATH;
 
+        [SuppressMessage("Performance", "HLQ005:Avoid Single() and SingleOrDefault()")]
         static LogProjectUtils()
         {
             string unityRootPath = Path.GetDirectoryName(EditorApplication.applicationPath) ?? string.Empty;
@@ -67,6 +69,7 @@ namespace Anvil.Unity.Logging
             Application.OpenURL(GetFileURL(UNITY_SOLUTION_PATH));
         }
 
+        [SuppressMessage("Performance", "HLQ005:Avoid Single() and SingleOrDefault()")]
         private static void UpdateUnityProjectReferences()
         {
             string projectPath = Path.ChangeExtension(UNITY_SOLUTION_PATH, ".csproj") ?? string.Empty;


### PR DESCRIPTION
When [NetFabric.Hyperlinq.Analyzer](https://github.com/NetFabric/NetFabric.Hyperlinq.Analyzer) is installed it emits warnings about the use of `.Single()` because most of the time `.First()` is more appropriate.

Specific Error: https://github.com/NetFabric/NetFabric.Hyperlinq.Analyzer/blob/master/docs/reference/HLQ005_AvoidSingle.md


### What is the current behaviour?
Warnings are emitted for the use of `.Single()` in `LogProjectUtils`

### What is the new behaviour?
The warnings are suppressed.

In this case the use of `Single` is appropriate since we're asserting that there is only one of the queried value at the same time as the query.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
