### PR TITLE
Add root namespace to assembly definitions

### DIFF
--- a/Scripts/Editor/anvil-unity-core-editor.asmdef
+++ b/Scripts/Editor/anvil-unity-core-editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "anvil-unity-core-editor",
+    "rootNamespace": "Anvil.Unity.Editor",
     "references": [
         "anvil-csharp-core",
         "anvil-unity-core-runtime"

--- a/Scripts/Runtime/anvil-unity-core-runtime.asmdef
+++ b/Scripts/Runtime/anvil-unity-core-runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "anvil-unity-core-runtime",
+    "rootNamespace": "Anvil.Unity",
     "references": [
         "anvil-csharp-core"
     ],


### PR DESCRIPTION
Add root namespace to assembly definitions

### What is the current behaviour?
IDEs do not suggest correct name spaces because their root namespace value isn't being set in their CSProj files.

### What is the new behaviour?
IDEs do suggest the correct name spaces in anvil-unity-core.

Since Unity generates the CSProj files for each Assembly Definition the root namespace needs to be specified on the assembly definition.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
