### PR TITLE
Log Updates

### DIFF
--- a/Scripts/Runtime/Core/AbstractAnvilMonoBehaviour.cs
+++ b/Scripts/Runtime/Core/AbstractAnvilMonoBehaviour.cs
@@ -2,6 +2,7 @@
 using Anvil.CSharp.Logging;
 using Anvil.CSharp.Core;
 using UnityEngine;
+using Logger = Anvil.CSharp.Logging.Logger;
 
 namespace Anvil.Unity.Core
 {
@@ -23,12 +24,12 @@ namespace Anvil.Unity.Core
         /// </summary>
         public bool IsDisposing { get; private set; }
 
-        private Log.Logger? m_Logger;
+        private Logger? m_Logger;
         /// <summary>
         /// Returns a <see cref="Log.Logger"/> for this instance to emit log messages with.
         /// Lazy instantiated.
         /// </summary>
-        protected Log.Logger Logger
+        protected Logger Logger
         {
             get => m_Logger ?? (m_Logger = Log.GetLogger(this)).Value;
             set => m_Logger = value;
@@ -80,4 +81,3 @@ namespace Anvil.Unity.Core
         }
     }
 }
-

--- a/Scripts/Runtime/Logging/.CSProject/Anvil.Unity.Logging.csproj
+++ b/Scripts/Runtime/Logging/.CSProject/Anvil.Unity.Logging.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StateResetHelper.cs" />
     <Compile Include="UnityLogHandler.cs" />
     <Compile Include="UnityLogListener.cs" />
   </ItemGroup>

--- a/Scripts/Runtime/Logging/.CSProject/Anvil.Unity.Logging.csproj
+++ b/Scripts/Runtime/Logging/.CSProject/Anvil.Unity.Logging.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StateResetHelper.cs" />
+    <Compile Include="StaticStateResetHelper.cs" />
     <Compile Include="UnityLogHandler.cs" />
     <Compile Include="UnityLogListener.cs" />
   </ItemGroup>

--- a/Scripts/Runtime/Logging/.CSProject/StaticStateResetHelper.cs
+++ b/Scripts/Runtime/Logging/.CSProject/StaticStateResetHelper.cs
@@ -1,0 +1,18 @@
+using Anvil.CSharp.Logging;
+using UnityEngine;
+
+namespace Anvil.Unity.Logging
+{
+    /// <summary>
+    /// Hooks into <see cref="RuntimeInitializeOnLoadMethod"/> to reset static Log state
+    /// when projects don't perform domain reloads between runs.
+    /// </summary>
+    internal class StaticStateResetHelper
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            OneTimeLogger.Reset();
+        }
+    }
+}

--- a/Scripts/Runtime/Logging/.CSProject/StaticStateResetHelper.cs.meta
+++ b/Scripts/Runtime/Logging/.CSProject/StaticStateResetHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 87c32da738604588800033dca9be761f
+timeCreated: 1657901177

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using StackFrame = System.Diagnostics.StackFrame;
 using System.Collections.Concurrent;
 using System.Collections;
+using Logger = Anvil.CSharp.Logging.Logger;
 
 namespace Anvil.Unity.Logging
 {
@@ -16,7 +17,7 @@ namespace Anvil.Unity.Logging
     public sealed class UnityLogListener : ILogListener, UnityEngine.ILogHandler
     {
         /// <summary>
-        /// Place on a method to make the <see cref="UnityLogListener"> use the next 
+        /// Place on a method to make the <see cref="UnityLogListener"> use the next
         /// call up the stack for the log caller context.
         /// </summary>
         [AttributeUsage(AttributeTargets.Method)]
@@ -235,7 +236,7 @@ namespace Anvil.Unity.Logging
             //        - Debug.Log
             //         - UnityLogListener.LogFormat - Do nothing because m_IsHandlingBurstedLog = true
             //  - Something external (BurstCompilerService.Log?) emits the log to the Unity console
-            //      
+            //
             // From a Log.Logger instance
             //  - Log.Logger.Debug
             //   - Log.DispatchLog - set Log.IsHandlingLog = true
@@ -276,7 +277,7 @@ namespace Anvil.Unity.Logging
             // 4 - Caller of Debug.Log(+Warning, +Error, ...), Assert
             (StackFrame callerFrame, MethodBase callerMethod) = ResolveCaller(4);
 
-            Log.Logger logger = context != null ? Log.GetLogger(context) : Log.GetStaticLogger(ResolveContextFromMethod(callerMethod));
+            Logger logger = context != null ? Log.GetLogger(context) : Log.GetStaticLogger(ResolveContextFromMethod(callerMethod));
             logger.AtLevel(logLevel, message, callerFrame.GetFileName(), callerMethod?.Name, callerFrame.GetFileLineNumber());
         }
 
@@ -284,7 +285,7 @@ namespace Anvil.Unity.Logging
         {
             StackFrame callerFrame;
             MethodBase callerMethod;
-            // Walk up the stack until we're at a caller that isn't Unity's proxy or a method that we 
+            // Walk up the stack until we're at a caller that isn't Unity's proxy or a method that we
             // want to skip (Ex: Logger objects).
             do
             {

--- a/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
+++ b/Scripts/Runtime/Logging/Anvil.Unity.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a30793fd1aff184dcf1329a4f99684a0b65c8dc83759f3774214a6403dc509c3
+oid sha256:ea5163968191f6f25a4aa75de9638a09c360abea8f85efbfc515f4c84aa6cae2
 size 10752


### PR DESCRIPTION
Updates to support changes from https://github.com/decline-cookies/anvil-csharp-core/pull/91

### What is the current behaviour?
 - Uses of Logger are not compatible with latest changes to underlying Log types.
 - OneTime log messages do not emit after the first play in the editor when domain reload is disabled.

### What is the new behaviour?
 - Update references to support changes from https://github.com/decline-cookies/anvil-csharp-core/pull/91
 - Create `StaticStateResetHelper` in the Unity Logging dll to allow the state of the one time logs to be reset when domain reload is disabled.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - https://github.com/decline-cookies/anvil-csharp-core/pull/91

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
