### PR TITLE
Add ScreenUtil

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An opinionated collection of systems and utilities that add [Unity](https://unit
 Refer to the [anvil-csharp-core](https://github.com/decline-cookies/anvil-csharp-core) for a description of Anvil's purpose and the team's motivations.
 
 ## Expectations
+
 See: [anvil-csharp-core](https://github.com/decline-cookies/anvil-csharp-core)
 
 The code is reasonably clean but documentation and examples are sparse. Feel free to [reach out on Twitter](https://twitter.com/declinecookies) or open issues with questions.
@@ -12,18 +13,23 @@ The code is reasonably clean but documentation and examples are sparse. Feel fre
 ⚠️ We welcome PRs and bug reports but making this repo a public success is not our priority. No promises on when it will be addressed!
 
 # Dependencies
+
 - [Unity](https://unity.com/)
+  - [Unity.Mathematics](https://docs.unity3d.com/Packages/com.unity.mathematics@1.2/manual/index.html)
 - [anvil-csharp-core](https://github.com/decline-cookies/anvil-csharp-core)
 
 # Features
- - [ ] TODO: [#49](https://github.com/decline-cookies/anvil-unity-core/issues/49)
+
+- [ ] TODO: [#49](https://github.com/decline-cookies/anvil-unity-core/issues/49)
 
 # Project Setup
+
 1. Add [Dependencies](#dependencies) as submodules to your project
 2. Make use of [Features](#features) as desired.
 3. Done!
 
 This is the recommended Unity project folder structure:
+
 - Assets
   - Anvil
     - anvil-csharp-core

--- a/Scripts/Runtime/Core/Util/ScreenUtil.cs
+++ b/Scripts/Runtime/Core/Util/ScreenUtil.cs
@@ -1,0 +1,126 @@
+using Anvil.CSharp.Logging;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Anvil.Unity.Core
+{
+    /// <summary>
+    /// A collection of utilities for dealing with display screen resolutions
+    /// </summary>
+    public static class ScreenUtil
+    {
+        /// <summary>
+        /// The assumed base DPI for all edge border values provided to utility methods below.
+        /// This is used to normalize values against the current screen's DPI.
+        /// </summary>
+        public const float BASE_DPI = 102f;
+
+        /// <summary>
+        /// Normalizes an input position to the edges of <see cref="Screen"/> within the borders provided where bottom
+        /// left is (-1,-1) and top right is (1,1).
+        /// </summary>
+        /// <param name="position">The position to evaluate for normalization.</param>
+        /// <param name="edgeBorderX">
+        /// The pixel width on the horizontal edges of the screen that the <see cref="position"/> should be normalized
+        /// between.
+        /// </param>
+        /// <param name="edgeBorderY">
+        /// The pixel height on the vertical edges of the screen that the <see cref="position"/> should be normalized
+        /// between.
+        /// </param>
+        /// <param name="normalizeEdgeBordersToScreenDPI">
+        /// If true, the edge border values are normalized to the current screen DPI. Otherwise,
+        /// <see cref="edgeBorderX"/> and <see cref="edgeBorderY"/> are evaluated as raw pixel values.
+        ///
+        /// This is used to maintain a consistent physical sizes across all screen densities.
+        /// </param>
+        /// <param name="ignoreOffscreenValues">When the position is beyond the limits of the screen (Ex: x < 0, y > height, etc...) return 0,0 to prevent movement</param>
+        /// <returns>A position normalized within a screen edge border.</returns>
+        ///
+        /// <example>
+        /// Provided the <see cref="edgeBorderX"/> and <see cref="edgeBorderY"/> values of (10,10) and a screen size of
+        /// (100,100).
+        /// A <see cref="position"/> of (x,y) will be normalized to (x1,y1)
+        /// (0,0) -> (-1,-1)
+        /// (5,0) -> (-0.5,-1)
+        /// (50,0) -> (0,-1)
+        /// (95,0) -> (0.5,-1)
+        /// </example>
+        public static Vector2 NormalizeToScreenEdge(
+            Vector2 position,
+            float edgeBorderX,
+            float edgeBorderY,
+            bool normalizeEdgeBordersToScreenDPI = false,
+            bool ignoreOffscreenValues = true)
+        {
+            float screenWidth = Screen.width;
+            float screenHeight = Screen.height;
+
+            // If we're outside of the screen don't scroll
+            if (ignoreOffscreenValues
+                && (position.x < 0 || position.x > screenWidth || position.y < 0 || position.y > screenHeight)
+                )
+            {
+                return Vector2.zero;
+            }
+
+            if (normalizeEdgeBordersToScreenDPI)
+            {
+                float edgeBorderScaleFactor = GetDPIScaleFactor();
+                edgeBorderX *= edgeBorderX * edgeBorderScaleFactor;
+                edgeBorderY *= edgeBorderY * edgeBorderScaleFactor;
+            }
+
+            if (position.x <= edgeBorderX)
+            {
+                position.x = -1f + math.max(position.x / edgeBorderX, 0f);
+            }
+            else if (position.x >= screenWidth - edgeBorderX)
+            {
+                position.x = 1f - (math.max(screenWidth - position.x, 0f) / edgeBorderX);
+            }
+            else
+            {
+                position.x = 0f;
+            }
+
+            if (position.y <= edgeBorderY)
+            {
+                position.y = -1f + math.max(position.y / edgeBorderY, 0f);
+            }
+            else if (position.y >= screenHeight - edgeBorderY)
+            {
+                position.y = 1f - (math.max(screenHeight - position.y, 0f) / edgeBorderY);
+            }
+            else
+            {
+                position.y = 0;
+            }
+
+            return position;
+        }
+
+        /// <summary>
+        /// Calculate the factor to scale sizes by to maintain a consistent physical size across all screen densities.
+        /// It's assumed that the original size values were defined at <see cref="BASE_DPI"/>.
+        /// </summary>
+        /// <returns>The factor to scale sizes by based on the current display's DPI</returns>
+        public static float GetDPIScaleFactor()
+        {
+#if UNITY_ANDROID
+            // According to docs the DPI value returned isn't reliable on Android. The docs have a link to a forum post
+            // with a native implementation that works.
+            throw new NotSupportedException("NormalizeToScreenEdgeProcessor is not supported on Android. GetDPI needs to be implemented and tested. See: https://docs.unity3d.com/ScriptReference/Screen-dpi.html");
+#endif
+
+            float dpi = Screen.dpi;
+            if (dpi < float.Epsilon)
+            {
+                Log.GetStaticLogger(typeof(ScreenUtil)).Warning($"Screen.dpi is invalid. EdgeBorder values won't be normalized and will be evaluated as pixel values. Screen.dpi:{dpi}");
+                return 1;
+            }
+
+            return dpi / BASE_DPI;
+        }
+    }
+}

--- a/Scripts/Runtime/Core/Util/ScreenUtil.cs.meta
+++ b/Scripts/Runtime/Core/Util/ScreenUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ca77db6c235941ae88a8946b372214cf
+timeCreated: 1657134151

--- a/Scripts/Runtime/anvil-unity-core-runtime.asmdef
+++ b/Scripts/Runtime/anvil-unity-core-runtime.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "anvil-unity-core-runtime",
     "references": [
-        "anvil-csharp-core"
+        "anvil-csharp-core",
+        "Unity.Mathematics"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Add a collection of utilities to help deal with screens and resolutions.

### What is the current behaviour?
 - None

### What is the new behaviour?
Introduce methods to:
 - Provide normalized values between the edge of the screen and an arbitrary distance.
 - Normalize a scale value from one DPI to another.

Includes additional `Unity.Mathematics` dependency

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
