### PR TITLE
Improve Stripping Support

### DIFF
--- a/Scripts/Runtime/DelayedExecution/UpdateSources/UnityFixedUpdateSource.cs
+++ b/Scripts/Runtime/DelayedExecution/UpdateSources/UnityFixedUpdateSource.cs
@@ -1,4 +1,6 @@
-﻿namespace Anvil.Unity.DelayedExecution
+﻿using UnityEngine.Scripting;
+
+namespace Anvil.Unity.DelayedExecution
 {
     /// <summary>
     /// A specific <see cref="AbstractUnityUpdateSource"/> that dispatches
@@ -8,5 +10,8 @@
     /// </summary>
     public class UnityFixedUpdateSource : AbstractUnityUpdateSource<UnityFixedUpdateSourceMonoBehaviour>
     {
+        // Required to prevent constructor from being stripped when this type is referenced.
+        [RequiredMember]
+        public UnityFixedUpdateSource() : base() { }
     }
 }

--- a/Scripts/Runtime/DelayedExecution/UpdateSources/UnityLateUpdateSource.cs
+++ b/Scripts/Runtime/DelayedExecution/UpdateSources/UnityLateUpdateSource.cs
@@ -1,4 +1,6 @@
-﻿namespace Anvil.Unity.DelayedExecution
+﻿using UnityEngine.Scripting;
+
+namespace Anvil.Unity.DelayedExecution
 {
     /// <summary>
     /// A specific <see cref="AbstractUnityUpdateSource"/> that dispatches an <see cref="AbstractUnityUpdateSource{T}.OnUpdate"/>
@@ -7,5 +9,8 @@
     /// </summary>
     public class UnityLateUpdateSource : AbstractUnityUpdateSource<UnityLateUpdateSourceMonoBehaviour>
     {
+        // Required to prevent constructor from being stripped when this type is referenced.
+        [RequiredMember]
+        public UnityLateUpdateSource() : base() { }
     }
 }

--- a/Scripts/Runtime/DelayedExecution/UpdateSources/UnityUpdateSource.cs
+++ b/Scripts/Runtime/DelayedExecution/UpdateSources/UnityUpdateSource.cs
@@ -1,4 +1,6 @@
-﻿namespace Anvil.Unity.DelayedExecution
+﻿using UnityEngine.Scripting;
+
+namespace Anvil.Unity.DelayedExecution
 {
     /// <summary>
     /// A specific <see cref="AbstractUnityUpdateSource"/> that dispatches an <see cref="AbstractUnityUpdateSource{T}.OnUpdate"/>
@@ -7,5 +9,8 @@
     /// </summary>
     public class UnityUpdateSource : AbstractUnityUpdateSource<UnityUpdateSourceMonoBehaviour>
     {
+        // Required to prevent constructor from being stripped when this type is referenced.
+        [RequiredMember]
+        public UnityUpdateSource() : base() { }
     }
 }

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Anvil.CSharp.Logging;
 using UnityEngine;
+using UnityEngine.Scripting;
 using ILogHandler = Anvil.CSharp.Logging.ILogHandler;
 
 namespace Anvil.Unity.Logging
@@ -10,6 +11,7 @@ namespace Anvil.Unity.Logging
     /// Forwards logs from <see cref="Log"/> to <see cref="Debug"/>.
     /// </summary>
     [DefaultLogHandler(PRIORITY)]
+    [Preserve]
     public class UnityLogHandler : ILogHandler
     {
         public const uint PRIORITY = ConsoleLogHandler.PRIORITY + 10;

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using StackFrame = System.Diagnostics.StackFrame;
 using System.Collections.Concurrent;
 using System.Collections;
+using UnityEngine.Scripting;
 using Logger = Anvil.CSharp.Logging.Logger;
 
 namespace Anvil.Unity.Logging
@@ -14,6 +15,7 @@ namespace Anvil.Unity.Logging
     /// Captures all logging made through <see cref="Debug"/> and redirects them through a <see cref="Logger"/>.
     /// </summary>
     [DefaultLogListener]
+    [Preserve]
     public sealed class UnityLogListener : ILogListener, UnityEngine.ILogHandler
     {
         /// <summary>

--- a/Scripts/Runtime/Logging/anvil-unity-logging.dll
+++ b/Scripts/Runtime/Logging/anvil-unity-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37fa9c2480cdfba834374e539178dffa586f831f191a154d65bd4edb0cb964a3
+oid sha256:79b9524f698d9c45c6244d3d26c3c9a2573247bab3f34c39d6708db196c7b433
 size 11264

--- a/Scripts/Runtime/Logging/link.xml
+++ b/Scripts/Runtime/Logging/link.xml
@@ -1,7 +1,0 @@
-<linker>
-  <!--
-  Force include the Unity logger, as it is used through reflection and normally not referenced anywhere.
-  See: https://docs.unity3d.com/2021.1/Documentation/Manual/ManagedCodeStripping.html#LinkXML
-  -->
-  <assembly fullname="Anvil.Unity.Logging" />
-</linker>

--- a/Scripts/Runtime/Logging/link.xml.meta
+++ b/Scripts/Runtime/Logging/link.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 4f3d9ebb6c14b444abb68a637ffc9690
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
These changes allow Anvil to support the highest level of bytecode stripping built into Unity and makes the existing stripping defences more targeted to the exact types that require it. 

### What is the current behaviour?
When building a project that's using Anvil with [Managed Code Stripping](https://docs.unity3d.com/2021.3/Documentation/Manual/ManagedCodeStripping.html) set to `Low` or higher the build will throw exceptions.
 - All of the delayed execution update sources (Ex: `UnityFixedUpdateSource`) do not have default constructors
 - `UnityLogHandler` is not found as the default log handler.

### What is the new behaviour?
#### Fix Update Sources
Each concrete implementation of an update source now has a default constructor defined decorated with `[RequiredMember]` .
https://docs.unity3d.com/2021.3/Documentation/ScriptReference/Scripting.RequiredMemberAttribute.html

This prevents the default constructor from being stripped when the update source is referenced in the project.

**Note:** I did attempt to use [RequireDerivedAttribute](https://docs.unity3d.com/2021.3/Documentation/ScriptReference/Scripting.RequireDerivedAttribute.html) but it didn't drag along the default constructor.

#### Fix `UnityLogHandler`
This is an oversight from #70 where `link.xml` wasn't updated to reflect the new assembly name.
While fixing the issue I decided to migrate away from using `link.xml` and specifically add `[Preserve]` attributes to the log listener and log handler implementations.

The advantage to this approach:
 - Other unused logging types may be stripped rather than all being included even if not required.
 - Not affected by renaming assemblies

**Note:** Unfortunately we couldn't use [RequireImplementors](https://docs.unity3d.com/2021.3/Documentation/ScriptReference/Scripting.RequireImplementorsAttribute.html) because these attributes are Unity specific and the interfaces are defined in `anvil-csharp-core`.

### What issues does this resolve?
**Resolves:** #47

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
