### PR TITLE
ID provider static domain reloading.

### DIFF
--- a/Scripts/Runtime/Data/ID.meta
+++ b/Scripts/Runtime/Data/ID.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aee8b58c1a4a4feb91139030bf771885
+timeCreated: 1662477744

--- a/Scripts/Runtime/Data/ID/ID.cs
+++ b/Scripts/Runtime/Data/ID/ID.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace Anvil.Unity.Data
+{
+    /// <summary>
+    /// Resets the <see cref="CSharp.Data.ID"/> static class on load.
+    /// This allows for Unity's domain reloading to be disabled which speeds up Burst compiler development.
+    /// </summary>
+    internal static class ID
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Reset()
+        {
+            CSharp.Data.ID.Dispose();
+        }
+    }
+}

--- a/Scripts/Runtime/Data/ID/ID.cs.meta
+++ b/Scripts/Runtime/Data/ID/ID.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0295a1941cb74ce69933d7d138b4d840
+timeCreated: 1662477752


### PR DESCRIPTION
The `ID` static class in https://github.com/decline-cookies/anvil-csharp-core/pull/109 could preserve unwanted state when running in the editor with domain reloading turned off.

### What is the current behaviour?

ID Providers could stick around after a soft-reload in the app.

### What is the new behaviour?

ID providers are cleaned up.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - [Anvil CSharp #109](https://github.com/decline-cookies/anvil-csharp-core/pull/109)

### Does this introduce a breaking change?
 - [x] Yes
 - [ ] No
