### PR TITLE
Unity TraceListener

### DIFF
--- a/Scripts/Runtime/Debug.meta
+++ b/Scripts/Runtime/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3deaa595a3b50bd4985008fd95b5b3cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Debug/UnityTraceListener.cs
+++ b/Scripts/Runtime/Debug/UnityTraceListener.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine;
+
+namespace Anvil.Unity.Debugging
+{
+    /// <summary>
+    /// A custom <see cref="System.Diagnostics.TraceListener"> for Unity, to allow the use of <see cref="System.Diagnostics"> functions.
+    /// By default, all of the .NET Debug/Trace functions have no effect in Unity, without a listener manually forwarding calls.
+    /// 
+    /// The most common and important functions enabled by this listener are:
+    /// - <see cref="System.Diagnostics.Debug.WriteLine"> (forwarded to UnityEngine.Debug.Log)
+    /// - <see cref="System.Diagnostics.Debug.Assert"> (forwarded to a thrown exception)
+    /// 
+    /// Note: Both <see cref="System.Diagnostics.Debug"> and <see cref="System.Diagnostics.Trace"> functions use the same
+    /// listener, the difference is that Debug functions become no-ops in release builds, while Trace always works.
+    /// </summary>
+    public class UnityTraceListener : System.Diagnostics.TraceListener
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            System.Diagnostics.Trace.Listeners.Add(new UnityTraceListener());
+        }
+
+        public override void Write(string message) { UnityEngine.Debug.Log(message); }
+        public override void WriteLine(string message) { UnityEngine.Debug.Log(message); }
+
+        public override void Fail(string message) { throw new Exception(message); }
+        public override void Fail(string message, string details) { throw new Exception($"{message} {details}"); }
+    }
+}

--- a/Scripts/Runtime/Debug/UnityTraceListener.cs.meta
+++ b/Scripts/Runtime/Debug/UnityTraceListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd35388da8ade1941abc374f543e5d9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a `TraceListener` for Unity, to handle `System.Diagnostics.Debug.Assert()` calls and others.

Note: `System.Diagnostics.Debug...` and `System.Diagnostics.Trace...` functions map to the same listener, the difference is that `Debug` functions only execute in debug builds (i.e. when the `DEBUG` symbol is defined, which Unity does), while `Trace` works in all builds.

### What is the current behaviour?
Any calls under `System.Diagnostics.Debug/Trace` have no effect in Unity, as there's no listener mapping its called to Unity functions. I.e. `System.Diagnostics.Debug.Assert(...)` calls are ignored, even on failure.

### What is the new behaviour?
All `System.Diagnostics.Debug/Trace` calls work as expected, forwarding messages to Unity's console or throwing exceptions.

### What issues does this resolve?
Non-Unity code (ex. anvil-csharp-core) that uses `System.Diagnostics` functions for writing or assertions are ignored in Unity projects. This listeners ensures they will now work as expected.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No