### PR TITLE
Logging polish (part 2)

### DIFF
--- a/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
@@ -26,9 +26,14 @@ namespace Anvil.Unity.Logging
         {
             string callerFile = Path.GetFileNameWithoutExtension(callerPath);
 
-            string context = (callerLine > 0 ? $"{callerFile}:{callerLine}|{callerName}" : $"{callerFile}|{callerName}");
-
-            message = $"({context}) {message}";
+            if(callerLine > 0)
+            {
+               message = $"({callerFile}:{callerLine}|{callerName}) {message}"
+            }
+            else
+            {
+               message = $"({callerFile}|{callerName}) {message}"
+            }
 
             switch (level)
             {

--- a/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
@@ -24,7 +24,11 @@ namespace Anvil.Unity.Logging
             string callerName,
             int callerLine)
         {
-            message = $"({Path.GetFileNameWithoutExtension(callerPath)}:{callerLine}|{callerName}) {message}";
+            string callerFile = Path.GetFileNameWithoutExtension(callerPath);
+
+            string context = (callerLine > 0 ? $"{callerFile}:{callerLine}|{callerName}" : $"{callerFile}|{callerName}");
+
+            message = $"({context}) {message}";
 
             switch (level)
             {

--- a/Scripts/Runtime/Logging/anvil-unity-logging.dll
+++ b/Scripts/Runtime/Logging/anvil-unity-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ad0e9a87610064b1b7478e90a20ce72b1d1194e76328e65bc9361f26199ad85
+oid sha256:bef904573ffd3251d0456492a1c3f63a0d8366b4fd22b8bd03cbebb601309f05
 size 11776


### PR DESCRIPTION
Omit line number from log context when zero

### What is the current behaviour?
Logs from managed code have line number zero in the context, ex: `(UnityLogListener:0|.ctor) message`

### What is the new behaviour?
Logs from managed code now omit the line number, ex: `(UnityLogListener|.ctor) message`

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No

### Related
- https://github.com/decline-cookies/anvil-csharp-core/pull/115