### PR TITLE
NUnit test framework setup

### DIFF
--- a/Scripts/Editor/Tests.meta
+++ b/Scripts/Editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38909e6e0202edf47a53bba05b459fb6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Tests/anvil-unity-tests.asmdef
+++ b/Scripts/Editor/Tests/anvil-unity-tests.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "anvil-unity-tests",
+    "rootNamespace": "Anvil.Unity.Tests",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Scripts/Editor/Tests/anvil-unity-tests.asmdef.meta
+++ b/Scripts/Editor/Tests/anvil-unity-tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a09d70da376ff104387edcc7f3be777e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Setup for Unity's test framework, to allow writing and running NUnit tests.

### What issues does this resolve?
- A lack of unit testing to guard against regression

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [X] No

### Related
- https://github.com/decline-cookies/anvil-csharp-core/pull/117

---

By the simple addition of this .asmdef file, Unity will pick up any tests found until this editor-only assembly and display them in the "Test Runner" window (Window > General > Test Runner).

![image2](https://user-images.githubusercontent.com/1713664/194673992-f945fb17-58ac-42cf-a499-e3098f484d8c.png)

A similar Tests folder + asmdef could be set up for anvil-unity-dots, but I leave that up to others if deemed valuable. Unity also allows play mode tests, but until such time as a need for those arises, only edit mode tests were set up here.

### NUnit
[NUnit Reference](https://docs.nunit.org/articles/nunit/writing-tests/assertions/assertions.html)
[Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/manual/index.html)

Writing tests is as easy as adding a `[Test]` attribute to a function, and using NUnit's `Assert.That(...)` system to test functionality. 

Here's an example script:
```cs
using NUnit.Framework;
using Anvil.CSharp.Logging;

namespace Anvil.Unity.Tests
{
    public static class LoggerTests
    {
        [Test]
        public static void TestStaticLogger()
        {
            Logger logger = Log.GetStaticLogger(typeof(LoggerTests));

            Assert.That(logger.DerivedTypeName, Is.EqualTo(nameof(LoggerTests)));
        }
    }
}
```