### PR TITLE
Ignore .meta files in logging DLL project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Logging project (not imported by Unity)
+/Scripts/Runtime/Logging/.CSProject/**/*.meta


### PR DESCRIPTION
Ignore `.meta` files in the logging DLL project director.
This directory doesn't get imported by Unity so it shouldn't have any `.meta` files.

### What is the current behaviour?
`.meta` files may be accidentally added to the `.CSProject` logging directory.

### What is the new behaviour?
`.meta` files are ignored in `.CSPRoject` all all sub-directories.

### What issues does this resolve?
None
<!-- None is a perfectly valid answer -->

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
