### PR TITLE
Implement PreventAutoRefreshWhilePlaying

### DIFF
--- a/Scripts/Editor/AssetImport.meta
+++ b/Scripts/Editor/AssetImport.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9d807086ff6443c2b0077bf9bdf31957
+timeCreated: 1665672720

--- a/Scripts/Editor/AssetImport/PreventAutoRefreshWhilePlaying.cs
+++ b/Scripts/Editor/AssetImport/PreventAutoRefreshWhilePlaying.cs
@@ -1,0 +1,108 @@
+using Anvil.CSharp.Logging;
+using UnityEditor;
+
+namespace Anvil.Unity.Editor.AssetImport
+{
+    /// <summary>
+    /// Prevents the asset database from refreshing while the editor is in play mode.
+    /// This means that any changed assets aren't imported and changed source isn't recompiled.
+    ///
+    /// NOTE: When this is enabled it overrides the behaviour of
+    /// Preferences -> General -> Script Changes While Playing
+    /// (In versions of Unity that include that option)
+    /// </summary>
+    [InitializeOnLoad]
+    public static class PreventAutoRefreshWhilePlaying
+    {
+        private const string MENU_PATH = "Anvil/Prevent Asset Refresh While Playing";
+        private const string PREFSKEY_IS_ENABLED = MENU_PATH + ":IsEnabled";
+
+        private static readonly Logger s_Logger = Log.GetStaticLogger(typeof(PreventAutoRefreshWhilePlaying));
+        private static bool s_IsAutoRefreshDisabled = false;
+
+        private static bool IsEnabled
+        {
+            get => EditorPrefs.GetBool(PREFSKEY_IS_ENABLED);
+            set => EditorPrefs.SetBool(PREFSKEY_IS_ENABLED, value);
+        }
+
+        static PreventAutoRefreshWhilePlaying()
+        {
+            EditorApplication.playModeStateChanged += EditorApplication_PlayModeStateChanged;
+        }
+
+        [MenuItem(MENU_PATH)]
+        private static void ToggleEnabled()
+        {
+            IsEnabled = !IsEnabled;
+
+            if (IsEnabled)
+            {
+                EditorUtility.DisplayDialog(
+                    "Note",
+                    "Enabling this option prevents assets and scripts from reloading while the editor is playing. This overrides the behaviour of \"Preferences -> General -> Script Changes While Playing\".",
+                    "Thanks Boss"
+                    );
+            }
+
+            bool shouldPreventRefresh = IsEnabled && EditorApplication.isPlaying;
+            if (shouldPreventRefresh)
+            {
+                PreventAutoRefresh();
+            }
+            else
+            {
+                AllowAutoRefresh();
+            }
+        }
+
+        [MenuItem(MENU_PATH, true)]
+        private static bool ToggleEnabled_Validator()
+        {
+            // Make sure the menu is showing the correct checked state
+            Menu.SetChecked(MENU_PATH, IsEnabled);
+            return true;
+        }
+
+        private static void EditorApplication_PlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (!IsEnabled)
+            {
+                return;
+            }
+
+            switch (state)
+            {
+                case PlayModeStateChange.EnteredPlayMode:
+                    PreventAutoRefresh();
+                    break;
+
+                case PlayModeStateChange.EnteredEditMode:
+                    AllowAutoRefresh();
+                    break;
+            }
+        }
+
+        private static void PreventAutoRefresh()
+        {
+            if (!s_IsAutoRefreshDisabled)
+            {
+                s_IsAutoRefreshDisabled = true;
+                AssetDatabase.DisallowAutoRefresh();
+                s_Logger.Debug("Auto asset refresh disabled.");
+            }
+        }
+
+        private static void AllowAutoRefresh()
+        {
+            if (s_IsAutoRefreshDisabled)
+            {
+                AssetDatabase.AllowAutoRefresh();
+                s_IsAutoRefreshDisabled = false;
+                s_Logger.Debug("Auto asset refresh enabled.");
+
+                AssetDatabase.Refresh();
+            }
+        }
+    }
+}

--- a/Scripts/Editor/AssetImport/PreventAutoRefreshWhilePlaying.cs.meta
+++ b/Scripts/Editor/AssetImport/PreventAutoRefreshWhilePlaying.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e6bfacba8fd3423f82b87778dc5e5c3a
+timeCreated: 1665672737


### PR DESCRIPTION
Add option to prevent Unity from refreshing the asset database (import/compile) while the editor is playing.
Option located at `Anvil -> Prevent Asset Refresh While Playing`

### What is the current behaviour?
Recent versions of Unity have either broken or removed the preference that controlled this (`Preferences -> General -> Script Changes While Playing`)

Changing code while the editor is running, even when `Recompile After Finished Playing` triggers an import operation that blocks input.

### What is the new behaviour?
If enabled, prevents unity from refreshing the asset database (import/compile) while the editor playing.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No - The option is disabled by default
