### PR TITLE
UnityLogListener - Make thread safe + bug fixes

### DIFF
--- a/Scripts/Runtime/Logging/anvil-unity-logging.dll
+++ b/Scripts/Runtime/Logging/anvil-unity-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d29d42160f7624f07befa810c507c21ececac615cc83817a0323fa38b54bcf69
-size 11264
+oid sha256:ec2885f4d88dc97ffbcc3066d333cc7042e37ff6bdcd9864c045b307c50de7e7
+size 12800


### PR DESCRIPTION
All logging calls into `UnityLogListener` are now thread safe. This is an interim fix until the proper work of making `Log` thread safe is done https://github.com/decline-cookies/anvil-csharp-core/issues/126

Also fixes an issue where the main thread pump game object wasn't getting run in the Unity editor when playing.

#### Tag Alongs
 - Add comment to reference changes needed when Log is made thread safe. #90 
 - `SKIPPED_STACK_FRAME_TYPES` now supports methods and type detection. This allows finer grained control where we want to skip specific methods but not the whole type in a stack

### What is the current behaviour?
If a developer calls `Debug.Log` (and friends) from within a job with the Burst compiler disabled the `Log.IsHandlingLog` check will throw an error because two threads are trying to log at once. This is because while `Debug.Log` is thread safe, `UnityLogListener.LogFormat/LogException` are not.

When the burst compiler is enabled this error is not encountered because logs emitted from burst compiled code bypass `LogFormat/LogException` and go straight through to the `Application.logMessageReceivedThreaded` event.

#### Main thread Pump in Editor
When transitioning from editor to play mode the main thread pump game object is removed from the player loop and left in editor space. This meant that logs received through `Application.logMessageReceivedThreaded` were piling up in the `pendingLogs` queue and never getting sent through the `Log`.

### What is the new behaviour?
 - `Debug.LogException/LogFormat` off main thread calls are now marshalled through the pending logs queue just like the burst logs.
 - Refactor the log context building logic to make it easier to package up and either send to Log immediately or later. This also allows log context to be built on thread rather than only on the main thread.

#### Main thread Pump in Editor
Non-main thread logs now correctly pass through to handlers. The pump is re-created during the `SubsystemRegistration` phase at play time.

#### Tag Along
 - `SKIPPED_STACK_FRAME_TYPES` now supports methods and type detection. As a result, the call site at `UnityEngine.Application.CallLogCallback` is now skipped


### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
