### PR TITLE
OpenCommonPathsMenu - Implement

### DIFF
--- a/Scripts/Editor/Data/OpenCommonPathsMenu.cs
+++ b/Scripts/Editor/Data/OpenCommonPathsMenu.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using Anvil.CSharp.Logging;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anvil.Unity.Editor.Data
+{
+    internal static class OpenCommonPathsMenu
+    {
+        [MenuItem("Anvil/Open Common Path/Persistent Data Directory")]
+        internal static void OpenPersistentDataDirectory() => CreateAndOpen(Application.persistentDataPath);
+
+        [MenuItem("Anvil/Open Common Path/Temporary Cache Directory")]
+        internal static void OpenTemporaryCacheDirectory() => CreateAndOpen(Application.temporaryCachePath);
+
+        [MenuItem("Anvil/Open Common Path/Assets Directory")]
+        internal static void OpenDataDirectory() => CreateAndOpen(Application.dataPath);
+
+        private static void CreateAndOpen(string path)
+        {
+            Log.GetStaticLogger(typeof(OpenCommonPathsMenu)).Debug($"Opening: {path}");
+
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            Application.OpenURL("file://" + Uri.EscapeUriString(path));
+        }
+    }
+}

--- a/Scripts/Editor/Data/OpenCommonPathsMenu.cs.meta
+++ b/Scripts/Editor/Data/OpenCommonPathsMenu.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 12bf1c4d783b45018ce2db05574b62aa
+timeCreated: 1666725699


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1426795/197873768-732378f7-6c0a-4428-8d87-9cd02525a10e.png)

Add convenient menu options to open common Unity paths

### What is the current behaviour?
Developers usually memorize or debug.log the path and then copy into Explorer/Finder

### What is the new behaviour?
Developers can select a menu in the editor (or bind a keyboard shortcut).
Anvil -> Open Common Path -> ...

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
