### PR TITLE
Add `TransformExtension.SetLossyScale`

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
@@ -1,0 +1,41 @@
+using Anvil.Unity.Core;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Anvil.Unity.Tests
+{
+    public class TransformExtensionTests
+    {
+        [Test]
+        public static void SetLossyScaleTest()
+        {
+            Assert.That(nameof(SetLossyScaleTest), Does.StartWith(nameof(TransformExtension.SetLossyScale)));
+
+            Vector3 scale_two = new Vector3(2f, 2f, 2f);
+            Vector3 scale_two_one_two = new Vector3(2f, 1f, 2f);
+
+            // Setup
+            GameObject parentGO = new GameObject();
+            Transform parentTransform = parentGO.transform;
+            parentTransform.localScale = scale_two;
+
+            GameObject childGO = new GameObject();
+            Transform childTransform = childGO.transform;
+            childTransform.SetParent(parentTransform, false);
+
+
+            // Tests
+            childTransform.SetLossyScale(scale_two);
+            Assert.That(childTransform.lossyScale, Is.EqualTo(scale_two));
+            Assert.That(childTransform.localScale, Is.EqualTo(new Vector3(1f,1f,1f)));
+
+            childTransform.SetLossyScale(scale_two_one_two);
+            Assert.That(childTransform.lossyScale, Is.EqualTo(scale_two_one_two));
+            Assert.That(childTransform.localScale, Is.EqualTo(new Vector3(1f, 0.5f, 1f)));
+
+            // Teardown
+            GameObject.DestroyImmediate(parentGO);
+            GameObject.DestroyImmediate(childGO);
+        }
+    }
+}

--- a/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs.meta
+++ b/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2a77a60bc27743419b67c9a6141098d7
+timeCreated: 1670275080

--- a/Scripts/Runtime/Core/Util/TransformExtension.cs
+++ b/Scripts/Runtime/Core/Util/TransformExtension.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace Anvil.Unity.Core
+{
+    /// <summary>
+    /// A collection of extension methods for working with <see cref="Transform"/>
+    /// </summary>
+    public static class TransformExtension
+    {
+        /// <summary>
+        /// Sets the world scale on a transform.
+        /// </summary>
+        /// <param name="transform">The transform to set the scale on.</param>
+        /// <param name="scale">The desired world scale.</param>
+        /// <remarks>Taken from: http://answers.unity.com/answers/1343678/view.html</remarks>
+        public static void SetLossyScale(this Transform transform, Vector3 scale)
+        {
+            transform.localScale = Vector3.one;
+            transform.localScale = new Vector3 (
+                scale.x/transform.lossyScale.x,
+                scale.y/transform.lossyScale.y,
+                scale.z/transform.lossyScale.z);
+        }
+    }
+}

--- a/Scripts/Runtime/Core/Util/TransformExtension.cs.meta
+++ b/Scripts/Runtime/Core/Util/TransformExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 79e8917c036d47c48f77487fe8fea5af
+timeCreated: 1668708724


### PR DESCRIPTION
Add `TransformExtension.SetLossyScale`.

### What is the current behaviour?

Developer must manually calculate the `localScale` value for a `Transform` to achieve a given world scale(`lossyScale`).

### What is the new behaviour?

`TransformExtension.SetLossyScale` provides a convenience method that allows developers to set the world scale value of a `Transform`

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
