### PR TITLE
Tests - Add nunit and Unity.Mathematics assembly to asmdef

### DIFF
--- a/Scripts/Editor/Tests/anvil-unity-tests.asmdef
+++ b/Scripts/Editor/Tests/anvil-unity-tests.asmdef
@@ -4,15 +4,21 @@
     "references": [
         "anvil-unity-core-runtime",
         "anvil-unity-core-editor",
-        "anvil-csharp-core"
+        "anvil-csharp-core",
+        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "anvil-csharp-logging.dll",
+        "anvil-unity-logging.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],

--- a/Scripts/Editor/Tests/anvil-unity-tests.asmdef
+++ b/Scripts/Editor/Tests/anvil-unity-tests.asmdef
@@ -5,6 +5,7 @@
         "anvil-unity-core-runtime",
         "anvil-unity-core-editor",
         "anvil-csharp-core",
+        "Unity.Mathematics",
         "UnityEditor.TestRunner",
         "UnityEngine.TestRunner"
     ],


### PR DESCRIPTION
Add nUnit, Unity TestRunner, and Unity.Mathematics assembly references to unit test ASMDef.

### What is the current behaviour?

Some nUnit features are not available because the DLL is not explicitly referenced (Ex: `TestFixtureAttribute`)
(at least not in Rider).
This also allows access to the Unity specific customizations on top of nUnit

Unity.Mathematics types (Ex: float3) can't be used in tests.

### What is the new behaviour?

IDE picks up on all attributes supported by nUnit, Unity Test Runner, and Unity.Mathematics.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No