### PR TITLE
Add `MathExtension`

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -1,31 +1,64 @@
+using Anvil.Unity.Core;
 using NUnit.Framework;
+using Unity.Mathematics;
+using UnityEngine;
 
 namespace Anvil.Unity.Tests
 {
     public static class MathExtensionTests
     {
+        private static int EqualityWithNaN(float3 a, float3 b)
+        {
+            return math.all(a.IsEqualOrNaN(b)) ? 0 : 1;
+        }
+
         [Test]
         public static void GetInverseTest()
         {
+            Assert.That(new float3(1f).GetInverse(), Is.EqualTo(new float3(1f)));
+            Assert.That(new float3(2f).GetInverse(), Is.EqualTo(new float3(0.5f)));
 
+            Assert.That(new float3(-1f).GetInverse(), Is.EqualTo(new float3(-1f)));
+            Assert.That(new float3(-2f).GetInverse(), Is.EqualTo(new float3(-0.5f)));
+
+            Assert.That(new float3(7f, -2f, 0f).GetInverse(), Is.EqualTo(new float3(1f/7f, -0.5f, float.PositiveInfinity)));
+
+            Assert.That(float3.zero.GetInverse(), Is.EqualTo(new float3(float.PositiveInfinity)));
+            Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN), Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)).Using<float3>(EqualityWithNaN));
         }
 
         [Test]
-        public static void GetInverseSafe()
+        public static void GetInverseSafeTest()
+        {
+            Assert.That(new float3(1f).GetInverseSafe(), Is.EqualTo(new float3(1f)));
+            Assert.That(new float3(2f).GetInverseSafe(), Is.EqualTo(new float3(0.5f)));
+
+            Assert.That(new float3(-1f).GetInverseSafe(), Is.EqualTo(new float3(-1f)));
+            Assert.That(new float3(-2f).GetInverseSafe(), Is.EqualTo(new float3(-0.5f)));
+
+            Assert.That(new float3(7f, -2f, 0f).GetInverseSafe(), Is.EqualTo(new float3(1f/7f, -0.5f, 0f)));
+
+            Assert.That(float3.zero.GetInverseSafe(), Is.EqualTo(float3.zero));
+            Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN).GetInverseSafe(), Is.EqualTo(new float3(0, 0, 0f)));
+        }
+
+        [Test]
+        public static void IsApproximatelyTest()
         {
 
         }
 
         [Test]
-        public static void IsApproximately()
+        public static void ToSignedInfiniteTest()
         {
 
         }
 
         [Test]
-        public static void ToSignedInfinite()
+        public static void IsEqualOrNaNTest()
         {
 
         }
+
     }
 }

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+
+namespace Anvil.Unity.Tests
+{
+    public static class MathExtensionTests
+    {
+        [Test]
+        public static void GetInverseTest()
+        {
+
+        }
+
+        [Test]
+        public static void GetInverseSafe()
+        {
+
+        }
+
+        [Test]
+        public static void IsApproximately()
+        {
+
+        }
+
+        [Test]
+        public static void ToSignedInfinite()
+        {
+
+        }
+    }
+}

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -12,9 +12,12 @@ namespace Anvil.Unity.Tests
             return math.all(a.IsEqualOrNaN(b)) ? 0 : 1;
         }
 
+        // ----- GetInverse ----- //
         [Test]
         public static void GetInverseTest()
         {
+            Assert.That(nameof(GetInverseTest), Does.StartWith(nameof(MathExtension.GetInverse)));
+
             Assert.That(new float3(1f).GetInverse(), Is.EqualTo(new float3(1f)));
             Assert.That(new float3(2f).GetInverse(), Is.EqualTo(new float3(0.5f)));
 
@@ -27,9 +30,12 @@ namespace Anvil.Unity.Tests
             Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN), Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)).Using<float3>(EqualityWithNaN));
         }
 
+        // ----- GetInverseSafe ----- //
         [Test]
         public static void GetInverseSafeTest()
         {
+            Assert.That(nameof(GetInverseSafeTest), Does.StartWith(nameof(MathExtension.GetInverseSafe)));
+
             Assert.That(new float3(1f).GetInverseSafe(), Is.EqualTo(new float3(1f)));
             Assert.That(new float3(2f).GetInverseSafe(), Is.EqualTo(new float3(0.5f)));
 
@@ -48,6 +54,7 @@ namespace Anvil.Unity.Tests
 
         }
 
+        // ----- ToSignedInfinite ----- //
         [Test]
         public static void ToSignedInfiniteTest()
         {

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -90,6 +90,7 @@ namespace Anvil.Unity.Tests
             float2 one = new float2(1f);
             float2 infinity_negativeInfinity = new float2(float.PositiveInfinity, float.NegativeInfinity);
             float2 naN = new float2(float.NaN);
+            float2 five_naN = new float2(5f, float.NaN);
 
             Assert.That(one.IsApproximately(one), Is.EqualTo(new bool2(true)));
             Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool2(true)));
@@ -110,6 +111,8 @@ namespace Anvil.Unity.Tests
 
             Assert.That(naN.IsApproximately(naN), Is.EqualTo(new bool2(false)));
             Assert.That(naN.IsApproximately(one), Is.EqualTo(new bool2(false)));
+
+            Assert.That(five_naN.IsApproximately(five_naN), Is.EqualTo(new bool2(true, false)));
         }
 
         [Test]
@@ -119,6 +122,7 @@ namespace Anvil.Unity.Tests
 
             float3 one = new float3(1f);
             float3 infinity_negativeInfinity_NaN = new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN);
+            float3 infinity_NaN_three = new float3(float.PositiveInfinity, float.NaN, 3f);
 
             Assert.That(one.IsApproximately(one), Is.EqualTo(new bool3(true)));
             Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool3(true)));
@@ -136,6 +140,8 @@ namespace Anvil.Unity.Tests
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(one), Is.EqualTo(new bool3(false)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false)));
+
+            Assert.That(infinity_NaN_three.IsApproximately(infinity_NaN_three), Is.EqualTo(new bool3(false, false, true)));
         }
 
         [Test]
@@ -273,6 +279,7 @@ namespace Anvil.Unity.Tests
             float2 one = new float2(1f);
             float2 infinity_negativeInfinity = new float2(float.PositiveInfinity, float.NegativeInfinity);
             float2 naN = new float2(float.NaN);
+            float2 five_naN = new float2(5f, float.NaN);
 
             Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool2(true)));
             Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool2(true)));
@@ -293,6 +300,8 @@ namespace Anvil.Unity.Tests
 
             Assert.That(naN.IsApproximatelySafe(naN), Is.EqualTo(new bool2(true)));
             Assert.That(naN.IsApproximatelySafe(one), Is.EqualTo(new bool2(false)));
+
+            Assert.That(five_naN.IsApproximatelySafe(five_naN), Is.EqualTo(new bool2(true)));
         }
 
         [Test]
@@ -302,6 +311,7 @@ namespace Anvil.Unity.Tests
 
             float3 one = new float3(1f);
             float3 infinity_negativeInfinity_NaN = new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN);
+            float3 infinity_NaN_three = new float3(float.PositiveInfinity, float.NaN, 3f);
 
             Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool3(true)));
             Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool3(true)));
@@ -311,14 +321,16 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one - new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
             Assert.That(one.IsApproximatelySafe(one + new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
 
-            Assert.That(one.IsApproximatelySafe(one - new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
-            Assert.That(one.IsApproximatelySafe(one + new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+            Assert.That(one.IsApproximatelySafe(one - new float3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
 
             Assert.That(float3.zero.IsApproximatelySafe(float3.zero), Is.EqualTo(new bool3(true)));
 
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(true)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(one), Is.EqualTo(new bool3(false)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false, false, true)));
+
+            Assert.That(infinity_NaN_three.IsApproximatelySafe(infinity_NaN_three), Is.EqualTo(new bool3(true)));
         }
 
         [Test]
@@ -327,7 +339,7 @@ namespace Anvil.Unity.Tests
             Assert.That(nameof(IsApproximatelySafeTest_float4), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
 
             float4 one = new float4(1f);
-            float4 infinity_negativeInfinity_NaN = new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN);
+            float4 infinity_negativeInfinity_NaN_three = new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f);
 
             Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool4(true)));
             Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool4(true)));
@@ -342,9 +354,9 @@ namespace Anvil.Unity.Tests
 
             Assert.That(float4.zero.IsApproximatelySafe(float4.zero), Is.EqualTo(new bool4(true)));
 
-            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(true)));
-            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(one), Is.EqualTo(new bool4(false)));
-            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(false, false, true, true)));
+            Assert.That(infinity_negativeInfinity_NaN_three.IsApproximatelySafe(infinity_negativeInfinity_NaN_three), Is.EqualTo(new bool4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_three.IsApproximatelySafe(one), Is.EqualTo(new bool4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_three.IsApproximatelySafe(-infinity_negativeInfinity_NaN_three), Is.EqualTo(new bool4(false, false, true, false)));
         }
 
         [Test]
@@ -387,12 +399,12 @@ namespace Anvil.Unity.Tests
             Assert.That(nameof(IsApproximatelySafeTest_float4x4), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
 
             float4x4 one = new float4x4(1f);
-            float4x4 infinity_negativeInfinity_NaN_column = new float4x4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN);
-            float4x4 infinity_negativeInfinity_NaN_row = new float4x4(
-                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
-                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
-                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
-                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN)
+            float4x4 infinity_negativeInfinity_NaN_three_column = new float4x4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f);
+            float4x4 infinity_negativeInfinity_NaN_three_row = new float4x4(
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f)
             );
 
             Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(true)));
@@ -408,12 +420,12 @@ namespace Anvil.Unity.Tests
 
             Assert.That(float4x4.zero.IsApproximatelySafe(float4x4.zero), Is.EqualTo(new bool4x4(true)));
 
-            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(true)));
-            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
-            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(-infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(false, false, true, true)));
+            Assert.That(infinity_negativeInfinity_NaN_three_column.IsApproximatelySafe(infinity_negativeInfinity_NaN_three_column), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_three_column.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_three_column.IsApproximatelySafe(-infinity_negativeInfinity_NaN_three_column), Is.EqualTo(new bool4x4(false, false, true, false)));
 
-            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool4x4(true)));
-            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_three_row.IsApproximatelySafe(infinity_negativeInfinity_NaN_three_row), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_three_row.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
         }
 
         // ----- ToSignedInfinite ----- //

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -70,10 +70,14 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one + (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
 
             Assert.That(0f.IsApproximately(0f), Is.True);
+
             Assert.That(infinity.IsApproximately(infinity), Is.False);
             Assert.That(infinity.IsApproximately(one), Is.False);
+            Assert.That(infinity.IsApproximately(negativeInfinity), Is.EqualTo(false));
+
             Assert.That(negativeInfinity.IsApproximately(negativeInfinity), Is.False);
             Assert.That(negativeInfinity.IsApproximately(one), Is.False);
+
             Assert.That(naN.IsApproximately(naN), Is.False);
             Assert.That(naN.IsApproximately(one), Is.False);
         }
@@ -99,8 +103,11 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one + new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
 
             Assert.That(float2.zero.IsApproximately(float2.zero), Is.EqualTo(new bool2(true)));
+
             Assert.That(infinity_negativeInfinity.IsApproximately(infinity_negativeInfinity), Is.EqualTo(new bool2(false)));
             Assert.That(infinity_negativeInfinity.IsApproximately(one), Is.EqualTo(new bool2(false)));
+            Assert.That(infinity_negativeInfinity.IsApproximately(-infinity_negativeInfinity), Is.EqualTo(new bool2(false)));
+
             Assert.That(naN.IsApproximately(naN), Is.EqualTo(new bool2(false)));
             Assert.That(naN.IsApproximately(one), Is.EqualTo(new bool2(false)));
         }
@@ -125,8 +132,10 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one + new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
 
             Assert.That(float3.zero.IsApproximately(float3.zero), Is.EqualTo(new bool3(true)));
+
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(one), Is.EqualTo(new bool3(false)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximately(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false)));
         }
 
         [Test]
@@ -149,8 +158,10 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one + new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
 
             Assert.That(float4.zero.IsApproximately(float4.zero), Is.EqualTo(new bool4(true)));
+
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(false)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximately(one), Is.EqualTo(new bool4(false)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximately(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(false)));
         }
 
         [Test]
@@ -178,8 +189,11 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one + new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
 
             Assert.That(float3x3.zero.IsApproximately(float3x3.zero), Is.EqualTo(new bool3x3(true)));
+
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool3x3(false)));
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(one), Is.EqualTo(new bool3x3(false)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(-infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool3x3(false)));
+
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool3x3(false)));
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(one), Is.EqualTo(new bool3x3(false)));
         }
@@ -210,8 +224,11 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one + new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
 
             Assert.That(float4x4.zero.IsApproximately(float4x4.zero), Is.EqualTo(new bool4x4(true)));
+
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(false)));
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(one), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(-infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(false)));
+
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool4x4(false)));
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(one), Is.EqualTo(new bool4x4(false)));
         }
@@ -237,10 +254,13 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one + (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
 
             Assert.That(0f.IsApproximatelySafe(0f), Is.True);
+
             Assert.That(infinity.IsApproximatelySafe(infinity), Is.True);
             Assert.That(infinity.IsApproximatelySafe(one), Is.False);
             Assert.That(negativeInfinity.IsApproximatelySafe(negativeInfinity), Is.True);
             Assert.That(negativeInfinity.IsApproximatelySafe(one), Is.False);
+            Assert.That(infinity.IsApproximatelySafe(negativeInfinity), Is.False);
+
             Assert.That(naN.IsApproximatelySafe(naN), Is.True);
             Assert.That(naN.IsApproximatelySafe(one), Is.False);
         }
@@ -266,8 +286,11 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one + new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
 
             Assert.That(float2.zero.IsApproximatelySafe(float2.zero), Is.EqualTo(new bool2(true)));
+
             Assert.That(infinity_negativeInfinity.IsApproximatelySafe(infinity_negativeInfinity), Is.EqualTo(new bool2(true)));
             Assert.That(infinity_negativeInfinity.IsApproximatelySafe(one), Is.EqualTo(new bool2(false)));
+            Assert.That(infinity_negativeInfinity.IsApproximatelySafe(-infinity_negativeInfinity), Is.EqualTo(new bool2(false)));
+
             Assert.That(naN.IsApproximatelySafe(naN), Is.EqualTo(new bool2(true)));
             Assert.That(naN.IsApproximatelySafe(one), Is.EqualTo(new bool2(false)));
         }
@@ -292,8 +315,10 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one + new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
 
             Assert.That(float3.zero.IsApproximatelySafe(float3.zero), Is.EqualTo(new bool3(true)));
+
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(true)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(one), Is.EqualTo(new bool3(false)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false, false, true)));
         }
 
         [Test]
@@ -316,8 +341,10 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one + new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
 
             Assert.That(float4.zero.IsApproximatelySafe(float4.zero), Is.EqualTo(new bool4(true)));
+
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(true)));
             Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(one), Is.EqualTo(new bool4(false)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(-infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(false, false, true, true)));
         }
 
         [Test]
@@ -345,8 +372,11 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one + new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
 
             Assert.That(float3x3.zero.IsApproximatelySafe(float3x3.zero), Is.EqualTo(new bool3x3(true)));
+
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool3x3(true)));
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(one), Is.EqualTo(new bool3x3(false)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(-infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool3x3(false, false, true)));
+
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool3x3(true)));
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(one), Is.EqualTo(new bool3x3(false)));
         }
@@ -377,8 +407,11 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one + new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
 
             Assert.That(float4x4.zero.IsApproximatelySafe(float4x4.zero), Is.EqualTo(new bool4x4(true)));
+
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(true)));
             Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(-infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(false, false, true, true)));
+
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool4x4(true)));
             Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
         }

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -1,3 +1,4 @@
+using Anvil.CSharp.Mathematics;
 using Anvil.Unity.Core;
 using NUnit.Framework;
 using Unity.Mathematics;
@@ -48,24 +49,579 @@ namespace Anvil.Unity.Tests
             Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN).GetInverseSafe(), Is.EqualTo(new float3(0, 0, 0f)));
         }
 
+        // ----- IsApproximately ----- //
         [Test]
-        public static void IsApproximatelyTest()
+        public static void IsApproximatelyTest_float()
         {
+            Assert.That(nameof(IsApproximatelyTest_float), Does.StartWith(nameof(MathExtension.IsApproximately)));
 
+            float one = 1f;
+            float infinity = float.PositiveInfinity;
+            float negativeInfinity = float.NegativeInfinity;
+            float naN = float.NaN;
+
+            Assert.That(one.IsApproximately(one), Is.True);
+            Assert.That((-one).IsApproximately(-one), Is.True);
+
+            Assert.That(one.IsApproximately(one - float.Epsilon), Is.True);
+            Assert.That(one.IsApproximately(one + float.Epsilon), Is.True);
+
+            Assert.That(one.IsApproximately(one - (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+            Assert.That(one.IsApproximately(one + (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+
+            Assert.That(0f.IsApproximately(0f), Is.True);
+            Assert.That(infinity.IsApproximately(infinity), Is.False);
+            Assert.That(infinity.IsApproximately(one), Is.False);
+            Assert.That(negativeInfinity.IsApproximately(negativeInfinity), Is.False);
+            Assert.That(negativeInfinity.IsApproximately(one), Is.False);
+            Assert.That(naN.IsApproximately(naN), Is.False);
+            Assert.That(naN.IsApproximately(one), Is.False);
+        }
+
+        [Test]
+        public static void IsApproximatelyTest_float2()
+        {
+            Assert.That(nameof(IsApproximatelyTest_float2), Does.StartWith(nameof(MathExtension.IsApproximately)));
+
+            float2 one = new float2(1f);
+            float2 infinity_negativeInfinity = new float2(float.PositiveInfinity, float.NegativeInfinity);
+            float2 naN = new float2(float.NaN);
+
+            Assert.That(one.IsApproximately(one), Is.EqualTo(new bool2(true)));
+            Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool2(true)));
+
+            Assert.That(new float2(-1f, 1f).IsApproximately(one), Is.EqualTo(new bool2(false, true)));
+
+            Assert.That(one.IsApproximately(one - new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
+            Assert.That(one.IsApproximately(one + new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
+
+            Assert.That(one.IsApproximately(one - new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+            Assert.That(one.IsApproximately(one + new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+
+            Assert.That(float2.zero.IsApproximately(float2.zero), Is.EqualTo(new bool2(true)));
+            Assert.That(infinity_negativeInfinity.IsApproximately(infinity_negativeInfinity), Is.EqualTo(new bool2(false)));
+            Assert.That(infinity_negativeInfinity.IsApproximately(one), Is.EqualTo(new bool2(false)));
+            Assert.That(naN.IsApproximately(naN), Is.EqualTo(new bool2(false)));
+            Assert.That(naN.IsApproximately(one), Is.EqualTo(new bool2(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelyTest_float3()
+        {
+            Assert.That(nameof(IsApproximatelyTest_float3), Does.StartWith(nameof(MathExtension.IsApproximately)));
+
+            float3 one = new float3(1f);
+            float3 infinity_negativeInfinity_NaN = new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN);
+
+            Assert.That(one.IsApproximately(one), Is.EqualTo(new bool3(true)));
+            Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool3(true)));
+
+            Assert.That(new float3(-1f, 1f, -1f).IsApproximately(one), Is.EqualTo(new bool3(false, true, false)));
+
+            Assert.That(one.IsApproximately(one - new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
+            Assert.That(one.IsApproximately(one + new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
+
+            Assert.That(one.IsApproximately(one - new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+            Assert.That(one.IsApproximately(one + new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+
+            Assert.That(float3.zero.IsApproximately(float3.zero), Is.EqualTo(new bool3(true)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximately(infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(false)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximately(one), Is.EqualTo(new bool3(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelyTest_float4()
+        {
+            Assert.That(nameof(IsApproximatelyTest_float4), Does.StartWith(nameof(MathExtension.IsApproximately)));
+
+            float4 one = new float4(1f);
+            float4 infinity_negativeInfinity_NaN = new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN);
+
+            Assert.That(one.IsApproximately(one), Is.EqualTo(new bool4(true)));
+            Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool4(true)));
+
+            Assert.That(new float4(-1f, 1f, -1f, 1f).IsApproximately(one), Is.EqualTo(new bool4(false, true, false, true)));
+
+            Assert.That(one.IsApproximately(one - new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
+            Assert.That(one.IsApproximately(one + new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
+
+            Assert.That(one.IsApproximately(one - new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+            Assert.That(one.IsApproximately(one + new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+
+            Assert.That(float4.zero.IsApproximately(float4.zero), Is.EqualTo(new bool4(true)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximately(infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(false)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximately(one), Is.EqualTo(new bool4(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelyTest_float3x3()
+        {
+            Assert.That(nameof(IsApproximatelyTest_float3x3), Does.StartWith(nameof(MathExtension.IsApproximately)));
+
+            float3x3 one = new float3x3(1f);
+            float3x3 infinity_negativeInfinity_NaN_column = new float3x3(float.PositiveInfinity, float.NegativeInfinity, float.NaN);
+            float3x3 infinity_negativeInfinity_NaN_row = new float3x3(
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)
+                );
+
+            Assert.That(one.IsApproximately(one), Is.EqualTo(new bool3x3(true)));
+            Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool3x3(true)));
+
+            Assert.That(new float3x3(-1f, 1f, -1f).IsApproximately(one), Is.EqualTo(new bool3x3(false, true, false)));
+
+            Assert.That(one.IsApproximately(one - new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
+            Assert.That(one.IsApproximately(one + new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
+
+            Assert.That(one.IsApproximately(one - new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+            Assert.That(one.IsApproximately(one + new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+
+            Assert.That(float3x3.zero.IsApproximately(float3x3.zero), Is.EqualTo(new bool3x3(true)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool3x3(false)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(one), Is.EqualTo(new bool3x3(false)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool3x3(false)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(one), Is.EqualTo(new bool3x3(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelyTest_float4x4()
+        {
+            Assert.That(nameof(IsApproximatelyTest_float4x4), Does.StartWith(nameof(MathExtension.IsApproximately)));
+
+            float4x4 one = new float4x4(1f);
+            float4x4 infinity_negativeInfinity_NaN_column = new float4x4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN);
+            float4x4 infinity_negativeInfinity_NaN_row = new float4x4(
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN)
+            );
+
+            Assert.That(one.IsApproximately(one), Is.EqualTo(new bool4x4(true)));
+            Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool4x4(true)));
+
+            Assert.That(new float4x4(-1f, 1f, -1f, 1f).IsApproximately(one), Is.EqualTo(new bool4x4(false, true, false, true)));
+
+            Assert.That(one.IsApproximately(one - new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
+            Assert.That(one.IsApproximately(one + new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
+
+            Assert.That(one.IsApproximately(one - new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+            Assert.That(one.IsApproximately(one + new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+
+            Assert.That(float4x4.zero.IsApproximately(float4x4.zero), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximately(one), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximately(one), Is.EqualTo(new bool4x4(false)));
+        }
+
+        // ----- IsApproximatelySafe ----- //
+        [Test]
+        public static void IsApproximatelySafeTest_float()
+        {
+            Assert.That(nameof(IsApproximatelySafeTest_float), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
+
+            float one = 1f;
+            float infinity = float.PositiveInfinity;
+            float negativeInfinity = float.NegativeInfinity;
+            float naN = float.NaN;
+
+            Assert.That(one.IsApproximatelySafe(one), Is.True);
+            Assert.That((-one).IsApproximatelySafe(-one), Is.True);
+
+            Assert.That(one.IsApproximatelySafe(one - float.Epsilon), Is.True);
+            Assert.That(one.IsApproximatelySafe(one + float.Epsilon), Is.True);
+
+            Assert.That(one.IsApproximatelySafe(one - (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+            Assert.That(one.IsApproximatelySafe(one + (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+
+            Assert.That(0f.IsApproximatelySafe(0f), Is.True);
+            Assert.That(infinity.IsApproximatelySafe(infinity), Is.True);
+            Assert.That(infinity.IsApproximatelySafe(one), Is.False);
+            Assert.That(negativeInfinity.IsApproximatelySafe(negativeInfinity), Is.True);
+            Assert.That(negativeInfinity.IsApproximatelySafe(one), Is.False);
+            Assert.That(naN.IsApproximatelySafe(naN), Is.True);
+            Assert.That(naN.IsApproximatelySafe(one), Is.False);
+        }
+
+        [Test]
+        public static void IsApproximatelySafeTest_float2()
+        {
+            Assert.That(nameof(IsApproximatelySafeTest_float2), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
+
+            float2 one = new float2(1f);
+            float2 infinity_negativeInfinity = new float2(float.PositiveInfinity, float.NegativeInfinity);
+            float2 naN = new float2(float.NaN);
+
+            Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool2(true)));
+            Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool2(true)));
+
+            Assert.That(new float2(-1f, 1f).IsApproximatelySafe(one), Is.EqualTo(new bool2(false, true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
+            Assert.That(one.IsApproximatelySafe(one + new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+
+            Assert.That(float2.zero.IsApproximatelySafe(float2.zero), Is.EqualTo(new bool2(true)));
+            Assert.That(infinity_negativeInfinity.IsApproximatelySafe(infinity_negativeInfinity), Is.EqualTo(new bool2(true)));
+            Assert.That(infinity_negativeInfinity.IsApproximatelySafe(one), Is.EqualTo(new bool2(false)));
+            Assert.That(naN.IsApproximatelySafe(naN), Is.EqualTo(new bool2(true)));
+            Assert.That(naN.IsApproximatelySafe(one), Is.EqualTo(new bool2(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelySafeTest_float3()
+        {
+            Assert.That(nameof(IsApproximatelySafeTest_float3), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
+
+            float3 one = new float3(1f);
+            float3 infinity_negativeInfinity_NaN = new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN);
+
+            Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool3(true)));
+            Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool3(true)));
+
+            Assert.That(new float3(-1f, 1f, -1f).IsApproximatelySafe(one), Is.EqualTo(new bool3(false, true, false)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
+            Assert.That(one.IsApproximatelySafe(one + new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+
+            Assert.That(float3.zero.IsApproximatelySafe(float3.zero), Is.EqualTo(new bool3(true)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(infinity_negativeInfinity_NaN), Is.EqualTo(new bool3(true)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(one), Is.EqualTo(new bool3(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelySafeTest_float4()
+        {
+            Assert.That(nameof(IsApproximatelySafeTest_float4), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
+
+            float4 one = new float4(1f);
+            float4 infinity_negativeInfinity_NaN = new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN);
+
+            Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool4(true)));
+            Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool4(true)));
+
+            Assert.That(new float4(-1f, 1f, -1f, 1f).IsApproximatelySafe(one), Is.EqualTo(new bool4(false, true, false, true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
+            Assert.That(one.IsApproximatelySafe(one + new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+
+            Assert.That(float4.zero.IsApproximatelySafe(float4.zero), Is.EqualTo(new bool4(true)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(infinity_negativeInfinity_NaN), Is.EqualTo(new bool4(true)));
+            Assert.That(infinity_negativeInfinity_NaN.IsApproximatelySafe(one), Is.EqualTo(new bool4(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelySafeTest_float3x3()
+        {
+            Assert.That(nameof(IsApproximatelySafeTest_float3x3), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
+
+            float3x3 one = new float3x3(1f);
+            float3x3 infinity_negativeInfinity_NaN_column = new float3x3(float.PositiveInfinity, float.NegativeInfinity, float.NaN);
+            float3x3 infinity_negativeInfinity_NaN_row = new float3x3(
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)
+                );
+
+            Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool3x3(true)));
+            Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool3x3(true)));
+
+            Assert.That(new float3x3(-1f, 1f, -1f).IsApproximatelySafe(one), Is.EqualTo(new bool3x3(false, true, false)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
+            Assert.That(one.IsApproximatelySafe(one + new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+
+            Assert.That(float3x3.zero.IsApproximatelySafe(float3x3.zero), Is.EqualTo(new bool3x3(true)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool3x3(true)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(one), Is.EqualTo(new bool3x3(false)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool3x3(true)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(one), Is.EqualTo(new bool3x3(false)));
+        }
+
+        [Test]
+        public static void IsApproximatelySafeTest_float4x4()
+        {
+            Assert.That(nameof(IsApproximatelySafeTest_float4x4), Does.StartWith(nameof(MathExtension.IsApproximatelySafe)));
+
+            float4x4 one = new float4x4(1f);
+            float4x4 infinity_negativeInfinity_NaN_column = new float4x4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN);
+            float4x4 infinity_negativeInfinity_NaN_row = new float4x4(
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN)
+            );
+
+            Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(true)));
+            Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool4x4(true)));
+
+            Assert.That(new float4x4(-1f, 1f, -1f, 1f).IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false, true, false, true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
+            Assert.That(one.IsApproximatelySafe(one + new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
+
+            Assert.That(one.IsApproximatelySafe(one - new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+
+            Assert.That(float4x4.zero.IsApproximatelySafe(float4x4.zero), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(infinity_negativeInfinity_NaN_column), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_column.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(infinity_negativeInfinity_NaN_row), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity_NaN_row.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(false)));
         }
 
         // ----- ToSignedInfinite ----- //
         [Test]
         public static void ToSignedInfiniteTest()
         {
+            Assert.That(nameof(ToSignedInfiniteTest), Does.StartWith(nameof(MathExtension.ToSignedInfinite)));
 
+            float3 zero = float3.zero;
+            float3 one = new float3(1f);
+            float3 one_negativeOne_zero = new float3(1f, -1, 0);
+            float3 nan = new float3(float.NaN);
+
+            float3 infinity = new float3(float.PositiveInfinity);
+            float3 negativeInfinity = new float3(float.NegativeInfinity);
+            float3 infinity_negativeInfinity_zero = new float3(float.PositiveInfinity, float.NegativeInfinity, 0f);
+
+            Assert.That(zero.ToSignedInfinite(), Is.EqualTo(zero));
+            Assert.That(one.ToSignedInfinite(), Is.EqualTo(infinity));
+            Assert.That(-one.ToSignedInfinite(), Is.EqualTo(negativeInfinity));
+            Assert.That(one_negativeOne_zero.ToSignedInfinite(), Is.EqualTo(infinity_negativeInfinity_zero));
+
+            Assert.That(nan.ToSignedInfinite(), Is.EqualTo(nan).Using<float3>(EqualityWithNaN));
+
+            Assert.That(infinity.ToSignedInfinite(), Is.EqualTo(infinity));
+            Assert.That(negativeInfinity.ToSignedInfinite(), Is.EqualTo(negativeInfinity));
+            Assert.That(infinity_negativeInfinity_zero.ToSignedInfinite(), Is.EqualTo(infinity_negativeInfinity_zero));
+        }
+
+        // ----- IsEqualOrNaN ----- //
+        [Test]
+        public static void IsEqualOrNaNTest_float()
+        {
+            Assert.That(nameof(IsEqualOrNaNTest_float), Does.StartWith(nameof(MathExtension.IsEqualOrNaN)));
+
+            float zero = 0f;
+            float one = 1f;
+            float nan = float.NaN;
+            float infinity = float.PositiveInfinity;
+
+            Assert.That(zero.IsEqualOrNaN(zero), Is.True);
+            Assert.That(zero.IsEqualOrNaN(one), Is.False);
+
+            Assert.That(one.IsEqualOrNaN(one), Is.True);
+            Assert.That(one.IsEqualOrNaN(zero), Is.False);
+
+            Assert.That(one.IsEqualOrNaN(-one), Is.False);
+            Assert.That((-one).IsEqualOrNaN(-one), Is.True);
+
+            Assert.That(infinity.IsEqualOrNaN(infinity), Is.True);
+            Assert.That(one.IsEqualOrNaN(zero), Is.False);
+
+            Assert.That(nan.IsEqualOrNaN(nan), Is.True);
+            Assert.That(nan.IsEqualOrNaN(zero), Is.False);
+            Assert.That(nan.IsEqualOrNaN(infinity), Is.False);
         }
 
         [Test]
-        public static void IsEqualOrNaNTest()
+        public static void IsEqualOrNaNTest_float2()
         {
+            Assert.That(nameof(IsEqualOrNaNTest_float2), Does.StartWith(nameof(MathExtension.IsEqualOrNaN)));
 
+            float2 zero = float2.zero;
+            float2 one = new float2(1f);
+            float2 one_negativeOne = new float2(1f, -1);
+            float2 nan = new float2(float.NaN);
+            float2 nan_negativeOne = new float2(float.NaN, -1);
+            float2 infinity_negativeInfinity = new float2(float.PositiveInfinity, float.NegativeInfinity);
+
+            Assert.That(zero.IsEqualOrNaN(zero), Is.EqualTo(new bool2(true)));
+            Assert.That(zero.IsEqualOrNaN(one), Is.EqualTo(new bool2(false)));
+
+            Assert.That(one.IsEqualOrNaN(one), Is.EqualTo(new bool2(true)));
+            Assert.That(one.IsEqualOrNaN(zero), Is.EqualTo(new bool2(false)));
+
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(infinity_negativeInfinity), Is.EqualTo(new bool2(true)));
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(zero), Is.EqualTo(new bool2(false)));
+
+            Assert.That(one_negativeOne.IsEqualOrNaN(one_negativeOne), Is.EqualTo(new bool2(true)));
+            Assert.That(one_negativeOne.IsEqualOrNaN(one), Is.EqualTo(new bool2(true, false)));
+
+            Assert.That(nan.IsEqualOrNaN(nan), Is.EqualTo(new bool2(true)));
+            Assert.That(nan.IsEqualOrNaN(zero), Is.EqualTo(new bool2(false)));
+
+            Assert.That(nan_negativeOne.IsEqualOrNaN(nan_negativeOne), Is.EqualTo(new bool2(true)));
+            Assert.That(nan_negativeOne.IsEqualOrNaN(-nan_negativeOne), Is.EqualTo(new bool2(true, false)));
+            Assert.That(nan_negativeOne.IsEqualOrNaN(-one), Is.EqualTo(new bool2(false, true)));
         }
 
+        [Test]
+        public static void IsEqualOrNaNTest_float3()
+        {
+            Assert.That(nameof(IsEqualOrNaNTest_float3), Does.StartWith(nameof(MathExtension.IsEqualOrNaN)));
+
+            float3 zero = float3.zero;
+            float3 one = new float3(1f);
+            float3 one_negativeOne_zero = new float3(1f, -1, 0);
+            float3 nan = new float3(float.NaN);
+            float3 infinity_negativeInfinity = new float3(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity);
+            float3 nan_negativeOne_zero = new float3(float.NaN, -1, 0);
+
+            Assert.That(zero.IsEqualOrNaN(zero), Is.EqualTo(new bool3(true)));
+            Assert.That(zero.IsEqualOrNaN(one), Is.EqualTo(new bool3(false)));
+
+            Assert.That(one.IsEqualOrNaN(one), Is.EqualTo(new bool3(true)));
+            Assert.That(one.IsEqualOrNaN(zero), Is.EqualTo(new bool3(false)));
+
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(infinity_negativeInfinity), Is.EqualTo(new bool3(true)));
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(zero), Is.EqualTo(new bool3(false)));
+
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(one_negativeOne_zero), Is.EqualTo(new bool3(true)));
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(zero), Is.EqualTo(new bool3(false, false, true)));
+
+            Assert.That(nan.IsEqualOrNaN(nan), Is.EqualTo(new bool3(true)));
+            Assert.That(nan.IsEqualOrNaN(zero), Is.EqualTo(new bool3(false)));
+
+            Assert.That(nan_negativeOne_zero.IsEqualOrNaN(nan_negativeOne_zero), Is.EqualTo(new bool3(true)));
+            Assert.That(nan_negativeOne_zero.IsEqualOrNaN(-nan_negativeOne_zero), Is.EqualTo(new bool3(true, false, true)));
+            Assert.That(nan_negativeOne_zero.IsEqualOrNaN(zero), Is.EqualTo(new bool3(false, false, true)));
+        }
+
+        [Test]
+        public static void IsEqualOrNaNTest_float4()
+        {
+            Assert.That(nameof(IsEqualOrNaNTest_float4), Does.StartWith(nameof(MathExtension.IsEqualOrNaN)));
+
+            float4 zero = float4.zero;
+            float4 one = new float4(1f);
+            float4 one_negativeOne_zero = new float4(1f, -1, 0, 0);
+            float4 nan = new float4(float.NaN);
+            float4 infinity_negativeInfinity = new float4(float.PositiveInfinity, float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity);
+            float4 nan_negativeOne_zero = new float4(float.NaN, -1, 0, 0);
+
+            Assert.That(zero.IsEqualOrNaN(zero), Is.EqualTo(new bool4(true)));
+            Assert.That(zero.IsEqualOrNaN(one), Is.EqualTo(new bool4(false)));
+
+            Assert.That(one.IsEqualOrNaN(one), Is.EqualTo(new bool4(true)));
+            Assert.That(one.IsEqualOrNaN(zero), Is.EqualTo(new bool4(false)));
+
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(infinity_negativeInfinity), Is.EqualTo(new bool4(true)));
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(zero), Is.EqualTo(new bool4(false)));
+
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(one_negativeOne_zero), Is.EqualTo(new bool4(true)));
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(zero), Is.EqualTo(new bool4(false, false, true, true)));
+
+            Assert.That(nan.IsEqualOrNaN(nan), Is.EqualTo(new bool4(true)));
+            Assert.That(nan.IsEqualOrNaN(zero), Is.EqualTo(new bool4(false)));
+
+            Assert.That(nan_negativeOne_zero.IsEqualOrNaN(nan_negativeOne_zero), Is.EqualTo(new bool4(true)));
+            Assert.That(nan_negativeOne_zero.IsEqualOrNaN(-nan_negativeOne_zero), Is.EqualTo(new bool4(true, false, true, true)));
+            Assert.That(nan_negativeOne_zero.IsEqualOrNaN(zero), Is.EqualTo(new bool4(false, false, true, true)));
+        }
+
+        [Test]
+        public static void IsEqualOrNaNTest_float3x3()
+        {
+            Assert.That(nameof(IsEqualOrNaNTest_float3x3), Does.StartWith(nameof(MathExtension.IsEqualOrNaN)));
+
+            float3x3 zero = float3x3.zero;
+            float3x3 one = new float3x3(1f);
+            float3x3 one_negativeOne_zero = new float3x3(1f, -1, 0);
+            float3x3 nan = new float3x3(float.NaN);
+            float3x3 infinity_negativeInfinity = new float3x3(float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity);
+            float3x3 nan_negativeOne_zero_columns = new float3x3(float.NaN, -1, 0);
+            float3x3 nan_negativeOne_zero_rows = new float3x3(
+                new float3(float.NaN, -1, 0),
+                new float3(float.NaN, -1, 0),
+                new float3(float.NaN, -1, 0));
+
+            Assert.That(zero.IsEqualOrNaN(zero), Is.EqualTo(new bool3x3(true)));
+            Assert.That(zero.IsEqualOrNaN(one), Is.EqualTo(new bool3x3(false)));
+
+            Assert.That(one.IsEqualOrNaN(one), Is.EqualTo(new bool3x3(true)));
+            Assert.That(one.IsEqualOrNaN(zero), Is.EqualTo(new bool3x3(false)));
+
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(infinity_negativeInfinity), Is.EqualTo(new bool3x3(true)));
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(zero), Is.EqualTo(new bool3x3(false)));
+
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(one_negativeOne_zero), Is.EqualTo(new bool3x3(true)));
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(zero), Is.EqualTo(new bool3x3(false, false, true)));
+
+            Assert.That(nan.IsEqualOrNaN(nan), Is.EqualTo(new bool3x3(true)));
+            Assert.That(nan.IsEqualOrNaN(zero), Is.EqualTo(new bool3x3(false)));
+
+            Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(nan_negativeOne_zero_columns), Is.EqualTo(new bool3x3(true)));
+            Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(-nan_negativeOne_zero_columns), Is.EqualTo(new bool3x3(true, false, true)));
+            Assert.That(nan_negativeOne_zero_rows.IsEqualOrNaN(nan_negativeOne_zero_rows), Is.EqualTo(new bool3x3(true)));
+            Assert.That(
+                nan_negativeOne_zero_rows.IsEqualOrNaN(-nan_negativeOne_zero_rows),
+                Is.EqualTo(new bool3x3(
+                    new bool3(true, false, true),
+                    new bool3(true, false, true),
+                    new bool3(true, false, true)))
+                );
+            Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(zero), Is.EqualTo(new bool3x3(false, false, true)));
+        }
+
+        [Test]
+        public static void IsEqualOrNaNTest_float4x4()
+        {
+            Assert.That(nameof(IsEqualOrNaNTest_float4x4), Does.StartWith(nameof(MathExtension.IsEqualOrNaN)));
+
+            float4x4 zero = float4x4.zero;
+            float4x4 one = new float4x4(1f);
+            float4x4 one_negativeOne_zero = new float4x4(1f, -1, 0, 0);
+            float4x4 nan = new float4x4(float.NaN);
+            float4x4 infinity_negativeInfinity = new float4x4(float.PositiveInfinity, float.PositiveInfinity, float.NegativeInfinity, float.NegativeInfinity);
+            float4x4 nan_negativeOne_zero_columns = new float4x4(float.NaN, -1, 0, 0);
+            float4x4 nan_negativeOne_zero_rows = new float4x4(
+                new float4(float.NaN, -1, 0, 0),
+                new float4(float.NaN, -1, 0, 0),
+                new float4(float.NaN, -1, 0, 0),
+                new float4(float.NaN, -1, 0, 0));
+
+            Assert.That(zero.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(true)));
+            Assert.That(zero.IsEqualOrNaN(one), Is.EqualTo(new bool4x4(false)));
+
+            Assert.That(one.IsEqualOrNaN(one), Is.EqualTo(new bool4x4(true)));
+            Assert.That(one.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false)));
+
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(infinity_negativeInfinity), Is.EqualTo(new bool4x4(true)));
+            Assert.That(infinity_negativeInfinity.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false)));
+
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(one_negativeOne_zero), Is.EqualTo(new bool4x4(true)));
+            Assert.That(one_negativeOne_zero.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false, false, true, true)));
+
+            Assert.That(nan.IsEqualOrNaN(nan), Is.EqualTo(new bool4x4(true)));
+            Assert.That(nan.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false)));
+
+            Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(nan_negativeOne_zero_columns), Is.EqualTo(new bool4x4(true)));
+            Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(-nan_negativeOne_zero_columns), Is.EqualTo(new bool4x4(true, false, true, true)));
+            Assert.That(nan_negativeOne_zero_rows.IsEqualOrNaN(nan_negativeOne_zero_rows), Is.EqualTo(new bool4x4(true)));
+            Assert.That(
+                nan_negativeOne_zero_rows.IsEqualOrNaN(-nan_negativeOne_zero_rows),
+                Is.EqualTo(new bool4x4(
+                    new bool4(true, false, true, true),
+                    new bool4(true, false, true, true),
+                    new bool4(true, false, true, true),
+                    new bool4(true, false, true, true)))
+                );
+            Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false, false, true, true)));
+        }
     }
 }

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -28,7 +28,7 @@ namespace Anvil.Unity.Tests
             Assert.That(new float3(7f, -2f, 0f).GetInverse(), Is.EqualTo(new float3(1f/7f, -0.5f, float.PositiveInfinity)));
 
             Assert.That(float3.zero.GetInverse(), Is.EqualTo(new float3(float.PositiveInfinity)));
-            Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN), Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)).Using<float3>(EqualityWithNaN));
+            Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN).GetInverse(), Is.EqualTo(new float3(0, 0, float.NaN)).Using<float3>(EqualityWithNaN));
         }
 
         // ----- GetInverseSafe ----- //

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs.meta
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 636e065027a14f85b2d5927e260e2b91
+timeCreated: 1670040601

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -26,7 +26,7 @@ namespace Anvil.Unity.Core
         }
 
         /// <summary>
-        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> or infinite components set to 0
+        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> or infinite components set to 0.
         /// </summary>
         /// <param name="value">The value to get the inverse of.</param>
         /// <returns>The inverted value</returns>
@@ -48,7 +48,7 @@ namespace Anvil.Unity.Core
         /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
         /// </returns>
         /// <remarks>
-        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximatelySafe"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsApproximately(this float a, float b)
@@ -67,7 +67,7 @@ namespace Anvil.Unity.Core
         /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
         /// </returns>
         /// <remarks>
-        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximatelySafe"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool2 IsApproximately(this float2 a, float2 b)
@@ -86,7 +86,7 @@ namespace Anvil.Unity.Core
         /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
         /// </returns>
         /// <remarks>
-        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximatelySafe"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool3 IsApproximately(this float3 a, float3 b)
@@ -105,7 +105,7 @@ namespace Anvil.Unity.Core
         /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
         /// </returns>
         /// <remarks>
-        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximatelySafe"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool4 IsApproximately(this float4 a, float4 b)
@@ -124,7 +124,7 @@ namespace Anvil.Unity.Core
         /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
         /// </returns>
         /// <remarks>
-        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximatelySafe"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool3x3 IsApproximately(this float3x3 a, float3x3 b)
@@ -147,7 +147,7 @@ namespace Anvil.Unity.Core
         /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
         /// </returns>
         /// <remarks>
-        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximatelySafe"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool4x4 IsApproximately(this float4x4 a, float4x4 b)

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -179,7 +179,7 @@ namespace Anvil.Unity.Core
         {
             return (math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)
                    | (math.isnan(a) & math.isnan(b))
-                   | (math.isinf(a) & math.isinf(b));
+                   | (math.isinf(a) & math.isinf(b) & a == b);
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Anvil.Unity.Core
         {
             return (math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)
                    | (math.isnan(a) & math.isnan(b))
-                   | (math.isinf(a) & math.isinf(b));
+                   | (math.isinf(a) & math.isinf(b) & a == b);
         }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace Anvil.Unity.Core
         {
             return (math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)
                    | (math.isnan(a) & math.isnan(b))
-                   | (math.isinf(a) & math.isinf(b));
+                   | (math.isinf(a) & math.isinf(b)  & a == b);
         }
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace Anvil.Unity.Core
         {
             return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE
                    | (math.isnan(a) & math.isnan(b))
-                   | (math.isinf(a) & math.isinf(b));
+                   | (math.isinf(a) & math.isinf(b) & a == b);
         }
 
         /// <summary>

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -1,0 +1,98 @@
+using System.Runtime.CompilerServices;
+using Anvil.CSharp.Mathematics;
+using Unity.Mathematics;
+
+namespace Anvil.Unity.Core
+{
+    /// <summary>
+    /// A collection of extension methods for working with types under the <see cref="Unity.Mathematics"/> namespace.
+    /// (float3, int2, etc..)
+    /// </summary>
+    public static class MathExtension
+    {
+        /// <summary>
+        /// Get the inverse of a <see cref="float3"/>.
+        /// </summary>
+        /// <remarks>
+        /// Any components that are 0 will invert to <see cref="float.NaN"/>.
+        /// Use <see cref="GetInverseSafe" /> if this is a possibility.
+        /// </remarks>
+        /// <param name="value">The value to get the inverse of.</param>
+        /// <returns>The inverted value</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetInverse(this float3 value)
+        {
+            return 1f / value;
+        }
+
+        /// <summary>
+        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> components set to 0
+        /// </summary>
+        /// <param name="value">The value to get the inverse of.</param>
+        /// <returns>The inverted value</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetInverseSafe(this float3 value)
+        {
+            float3 inverse = value.GetInverse();
+            return math.select(inverse, float3.zero, math.isnan(inverse));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsApproximately(this float a, float b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool2 IsApproximately(this float2 a, float2 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3 IsApproximately(this float3 a, float3 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4 IsApproximately(this float4 a, float4 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3x3 IsApproximately(this float3x3 a, float3x3 b)
+        {
+            return new bool3x3(
+                a.c0.IsApproximately(b.c0),
+                a.c1.IsApproximately(b.c1),
+                a.c2.IsApproximately(b.c2)
+            );
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4x4 IsApproximately(this float4x4 a, float4x4 b)
+        {
+            return new bool4x4(
+                a.c0.IsApproximately(b.c0),
+                a.c1.IsApproximately(b.c1),
+                a.c2.IsApproximately(b.c2),
+                a.c3.IsApproximately(b.c3)
+            );
+        }
+
+        /// <summary>
+        /// Converts the components of a value to infinite quantities where:
+        /// >0 = <see cref="float.PositiveInfinity"/>
+        /// <0 = <see cref="float.NegativeInfinity"/>
+        /// 0 = 0
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A signed infinite value.</returns>
+        public static float3 ToSignedInfinite(this float3 value)
+        {
+            return math.select(math.sign(value) * new float3(float.PositiveInfinity), value, value == 0);
+        }
+    }
+}

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -26,7 +26,7 @@ namespace Anvil.Unity.Core
         }
 
         /// <summary>
-        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> components set to 0
+        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> or infinite components set to 0
         /// </summary>
         /// <param name="value">The value to get the inverse of.</param>
         /// <returns>The inverted value</returns>
@@ -34,7 +34,7 @@ namespace Anvil.Unity.Core
         public static float3 GetInverseSafe(this float3 value)
         {
             float3 inverse = value.GetInverse();
-            return math.select(inverse, float3.zero, math.isnan(inverse));
+            return math.select(inverse, float3.zero, math.isinf(inverse) | math.isnan(inverse));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -37,30 +37,95 @@ namespace Anvil.Unity.Core
             return math.select(inverse, float3.zero, math.isinf(inverse) | math.isnan(inverse));
         }
 
+        /// <summary>
+        /// Checks if two <see cref="float"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float"/> to compare.</param>
+        /// <param name="b">The <see cref="float"/> to compare.</param>
+        /// <returns>
+        /// True if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsApproximately(this float a, float b)
         {
             return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
         }
 
+        /// <summary>
+        /// Checks if two <see cref="float2"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float2"/> to compare.</param>
+        /// <param name="b">The <see cref="float2"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool2 IsApproximately(this float2 a, float2 b)
         {
             return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
         }
 
+        /// <summary>
+        /// Checks if two <see cref="float3"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float3"/> to compare.</param>
+        /// <param name="b">The <see cref="float3"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool3 IsApproximately(this float3 a, float3 b)
         {
             return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
         }
 
+        /// <summary>
+        /// Checks if two <see cref="float4"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float4"/> to compare.</param>
+        /// <param name="b">The <see cref="float4"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool4 IsApproximately(this float4 a, float4 b)
         {
             return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
         }
 
+        /// <summary>
+        /// Checks if two <see cref="float3x3"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float3x3"/> to compare.</param>
+        /// <param name="b">The <see cref="float3x3"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool3x3 IsApproximately(this float3x3 a, float3x3 b)
         {
@@ -71,6 +136,19 @@ namespace Anvil.Unity.Core
             );
         }
 
+        /// <summary>
+        /// Checks if two <see cref="float4x4"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float4x4"/> to compare.</param>
+        /// <param name="b">The <see cref="float4x4"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as false with improved performance vs <see cref="IsApproximately"/>.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool4x4 IsApproximately(this float4x4 a, float4x4 b)
         {
@@ -79,6 +157,143 @@ namespace Anvil.Unity.Core
                 a.c1.IsApproximately(b.c1),
                 a.c2.IsApproximately(b.c2),
                 a.c3.IsApproximately(b.c3)
+            );
+        }
+
+        /// <summary>
+        /// Checks if two <see cref="float"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float"/> to compare.</param>
+        /// <param name="b">The <see cref="float"/> to compare.</param>
+        /// <returns>
+        /// True if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as true with the same logic as <see cref="IsEqualOrNaN"/> at
+        /// additional cost vs <see cref="IsApproximately"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsApproximatelySafe(this float a, float b)
+        {
+            return (math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)
+                   | (math.isnan(a) & math.isnan(b))
+                   | (math.isinf(a) & math.isinf(b));
+        }
+
+        /// <summary>
+        /// Checks if two <see cref="float2"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float2"/> to compare.</param>
+        /// <param name="b">The <see cref="float2"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as true with the same logic as <see cref="IsEqualOrNaN"/> at
+        /// additional cost vs <see cref="IsApproximately"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool2 IsApproximatelySafe(this float2 a, float2 b)
+        {
+            return (math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)
+                   | (math.isnan(a) & math.isnan(b))
+                   | (math.isinf(a) & math.isinf(b));
+        }
+
+        /// <summary>
+        /// Checks if two <see cref="float3"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float3"/> to compare.</param>
+        /// <param name="b">The <see cref="float3"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as true with the same logic as <see cref="IsEqualOrNaN"/> at
+        /// additional cost vs <see cref="IsApproximately"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3 IsApproximatelySafe(this float3 a, float3 b)
+        {
+            return (math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)
+                   | (math.isnan(a) & math.isnan(b))
+                   | (math.isinf(a) & math.isinf(b));
+        }
+
+        /// <summary>
+        /// Checks if two <see cref="float4"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float4"/> to compare.</param>
+        /// <param name="b">The <see cref="float4"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as true with the same logic as <see cref="IsEqualOrNaN"/> at
+        /// additional cost vs <see cref="IsApproximately"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4 IsApproximatelySafe(this float4 a, float4 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE
+                   | (math.isnan(a) & math.isnan(b))
+                   | (math.isinf(a) & math.isinf(b));
+        }
+
+        /// <summary>
+        /// Checks if two <see cref="float3x3"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float3x3"/> to compare.</param>
+        /// <param name="b">The <see cref="float3x3"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as true with the same logic as <see cref="IsEqualOrNaN"/> at
+        /// additional cost vs <see cref="IsApproximately"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3x3 IsApproximatelySafe(this float3x3 a, float3x3 b)
+        {
+            return new bool3x3(
+                a.c0.IsApproximatelySafe(b.c0),
+                a.c1.IsApproximatelySafe(b.c1),
+                a.c2.IsApproximatelySafe(b.c2)
+            );
+        }
+
+        /// <summary>
+        /// Checks if two <see cref="float4x4"/> values are approximately equal according to the
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </summary>
+        /// <param name="a">The <see cref="float4x4"/> to compare.</param>
+        /// <param name="b">The <see cref="float4x4"/> to compare.</param>
+        /// <returns>
+        /// True (component-wise) if the delta between <see cref="a"/> and <see cref="b"/> is less than
+        /// <see cref="MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE"/>.
+        /// </returns>
+        /// <remarks>
+        /// Resolves infinite and NaN comparisons as true with the same logic as <see cref="IsEqualOrNaN"/> at
+        /// additional cost vs <see cref="IsApproximately"/>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4x4 IsApproximatelySafe(this float4x4 a, float4x4 b)
+        {
+            return new bool4x4(
+                a.c0.IsApproximatelySafe(b.c0),
+                a.c1.IsApproximatelySafe(b.c1),
+                a.c2.IsApproximatelySafe(b.c2),
+                a.c3.IsApproximatelySafe(b.c3)
             );
         }
 
@@ -149,6 +364,43 @@ namespace Anvil.Unity.Core
         public static bool4 IsEqualOrNaN(this float4 a, float4 b)
         {
             return a == b | (math.isnan(a) & math.isnan(b));
+        }
+
+        /// <summary>
+        /// Compares two <see cref="float3x3"/>s and returns true if the components are equal.
+        /// Unlike <see cref="float3x3.Equals"/> this method considers <see cref="float.NaN"/> == <see cref="float.NaN"/>
+        /// to be true.
+        /// </summary>
+        /// <param name="a">The <see cref="float3x3"/> to compare.</param>
+        /// <param name="b">The <see cref="float3x3"/> to compare.</param>
+        /// <returns>True (component-wise) if the values are equal or both <see cref="float.NaN"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3x3 IsEqualOrNaN(this float3x3 a, float3x3 b)
+        {
+            return a == b
+                   | new bool3x3(
+                       math.isnan(a.c0) & math.isnan(b.c0),
+                       math.isnan(a.c1) & math.isnan(b.c1),
+                       math.isnan(a.c2) & math.isnan(b.c2));
+        }
+
+        /// <summary>
+        /// Compares two <see cref="float4x4"/>s and returns true if the components are equal.
+        /// Unlike <see cref="float4x4.Equals"/> this method considers <see cref="float.NaN"/> == <see cref="float.NaN"/>
+        /// to be true.
+        /// </summary>
+        /// <param name="a">The <see cref="float4x4"/> to compare.</param>
+        /// <param name="b">The <see cref="float4x4"/> to compare.</param>
+        /// <returns>True (component-wise) if the values are equal or both <see cref="float.NaN"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4x4 IsEqualOrNaN(this float4x4 a, float4x4 b)
+        {
+            return a == b
+                   | new bool4x4(
+                       math.isnan(a.c0) & math.isnan(b.c0),
+                       math.isnan(a.c1) & math.isnan(b.c1),
+                       math.isnan(a.c2) & math.isnan(b.c2),
+                       math.isnan(a.c3) & math.isnan(b.c3));
         }
     }
 }

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -94,5 +94,61 @@ namespace Anvil.Unity.Core
         {
             return math.select(math.sign(value) * new float3(float.PositiveInfinity), value, value == 0);
         }
+
+        /// <summary>
+        /// Compares two <see cref="float"/>s and returns true if the components are equal.
+        /// Unlike <see cref="float.Equals"/> this method considers <see cref="float.NaN"/> == <see cref="float.NaN"/>
+        /// to be true.
+        /// </summary>
+        /// <param name="a">The <see cref="float"/> to compare.</param>
+        /// <param name="b">The <see cref="float"/> to compare.</param>
+        /// <returns>True if the values are equal or both <see cref="float.NaN"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsEqualOrNaN(this float a, float b)
+        {
+            return a == b | (math.isnan(a) & math.isnan(b));
+        }
+
+        /// <summary>
+        /// Compares two <see cref="float2"/>s and returns true if the components are equal.
+        /// Unlike <see cref="float2.Equals"/> this method considers <see cref="float.NaN"/> == <see cref="float.NaN"/>
+        /// to be true.
+        /// </summary>
+        /// <param name="a">The <see cref="float2"/> to compare.</param>
+        /// <param name="b">The <see cref="float2"/> to compare.</param>
+        /// <returns>True (component-wise) if the values are equal or both <see cref="float.NaN"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool2 IsEqualOrNaN(this float2 a, float2 b)
+        {
+            return a == b | (math.isnan(a) & math.isnan(b));
+        }
+
+        /// <summary>
+        /// Compares two <see cref="float3"/>s and returns true if the components are equal.
+        /// Unlike <see cref="float3.Equals"/> this method considers <see cref="float.NaN"/> == <see cref="float.NaN"/>
+        /// to be true.
+        /// </summary>
+        /// <param name="a">The <see cref="float3"/> to compare.</param>
+        /// <param name="b">The <see cref="float3"/> to compare.</param>
+        /// <returns>True (component-wise) if the values are equal or both <see cref="float.NaN"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3 IsEqualOrNaN(this float3 a, float3 b)
+        {
+            return a == b | (math.isnan(a) & math.isnan(b));
+        }
+
+        /// <summary>
+        /// Compares two <see cref="float4"/>s and returns true if the components are equal.
+        /// Unlike <see cref="float4.Equals"/> this method considers <see cref="float.NaN"/> == <see cref="float.NaN"/>
+        /// to be true.
+        /// </summary>
+        /// <param name="a">The <see cref="float4"/> to compare.</param>
+        /// <param name="b">The <see cref="float4"/> to compare.</param>
+        /// <returns>True (component-wise) if the values are equal or both <see cref="float.NaN"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4 IsEqualOrNaN(this float4 a, float4 b)
+        {
+            return a == b | (math.isnan(a) & math.isnan(b));
+        }
     }
 }

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -14,7 +14,7 @@ namespace Anvil.Unity.Core
         /// Get the inverse of a <see cref="float3"/>.
         /// </summary>
         /// <remarks>
-        /// Any components that are 0 will invert to <see cref="float.NaN"/>.
+        /// Any components that are 0 will invert to <see cref="float.PositiveInfinity"/>.
         /// Use <see cref="GetInverseSafe" /> if this is a possibility.
         /// </remarks>
         /// <param name="value">The value to get the inverse of.</param>

--- a/Scripts/Runtime/Core/Util/MathExtension.cs.meta
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7cc4cfd8b85744769c93fc039f8428ae
+timeCreated: 1669948828


### PR DESCRIPTION
Add a series of extension methods that extend the capabilities of types under the `Unity.Mathematics` library.

### What is the current behaviour?
There are some common operations with `Unity.Mathematics` types that are cumbersome or error prone to type.

### What is the new behaviour?
The extension methods defined under `MathExtension` are as follows:
 - `GetInverse()`/`GetInverseSafe()` - Calculate the inverse of a `float3`
 - `IsApproximately`/`IsApproximatelySafe` - Calculate equality between two floating point values using the standard Anvil threshold defined by `MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE`
    - The safe variant resolves NaN using the same logic as `IsEqualOrNaN` and also handles equality of infinite values.
 - `ToSignedInfinite` - Returns signed infinite values for each component of a floating point value
 - `IsEqualOrNaN` - Performs a standard equality check but also resolves `float.NaN == float.NaN` to `true` (unlike standard equality checks).

#### Safe vs Fast Suffix Conventions
The extension methods in this PR all use the "Safe" suffix but this isn't an arbitrary choice. The guidelines I've been using are as follows:
 - **Safe** - Adds additional guards against edge case invalid values (NaN, Infinity, etc..) at the cost of performance. The developer can choose to use this method if they haven't already guarded against anomalous values.
 - **No Suffix** - Assumes input values are valid but doesn't make assumptions about the nature of the values beyond that.
 - **Fast** - Makes assumptions about the nature of the values provided to perform the operation more quickly.

**Example:**
The following is an example using invert. This is not an actual implementation in this PR but does help show the relationship between the suffix choices. This is roughly based on the difference between Unity's `math.inverse` and `math.fastinverse` methods.

 - `InvertMatrixSafe` - Accepts matrices that contain NaN and Infinite values, substituting in valid values (usually 0) and inverting the matrix using a general purpose algorithm. The developer can confidently throw any matrix at this and get a valid output at the cost of performance.
 - `InvertMatrix` - Will not guard against NaN and infinite meaning they may persist into the inverted matrix or propagate to other values in the matrix. The developer needs to ensure input values are valid (or check the output) but benefits from higher performance than the Safe variant.
 - `InvertMatrixFast` - In addition the the assumptions made in `InvertMatrix` the matrix is assumed to have an [orthonormal basis](https://en.wikipedia.org/wiki/Orthonormal_basis) that allows an optimized/shortcut algorithm perform the operation. The developer needs to be sure that the input matrix has the properties assumed by the method and benefits from the highest performance of the three variants.

### What issues does this resolve?
None

### What PRs does this depend on?
 - #95 
 - https://github.com/decline-cookies/anvil-csharp-core/pull/136

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
