### PR TITLE
Add Rect Utilities - Tests, AbsSize, AreEquivalent

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
@@ -7,9 +7,9 @@ namespace Anvil.Unity.Tests
     public static class RectUtilTests
     {
         [Test]
-        public static void CreateFromPointsTest()
+        public static void CreateFromPointsTest_TwoPoint()
         {
-            Assert.That(nameof(CreateFromPointsTest), Does.StartWith(nameof(RectUtil.CreateFromPoints)));
+            Assert.That(nameof(CreateFromPointsTest_TwoPoint), Does.StartWith(nameof(RectUtil.CreateFromPoints)));
 
             Rect rect = RectUtil.CreateFromPoints(new Vector2(1, 2), new Vector2(3, 4));
 
@@ -19,6 +19,26 @@ namespace Anvil.Unity.Tests
             Assert.That(rect.max.y, Is.EqualTo(4));
 
             rect = RectUtil.CreateFromPoints(new Vector2(3, 4), new Vector2(1, 2));
+
+            Assert.That(rect.min.x, Is.EqualTo(1));
+            Assert.That(rect.min.y, Is.EqualTo(2));
+            Assert.That(rect.max.x, Is.EqualTo(3));
+            Assert.That(rect.max.y, Is.EqualTo(4));
+        }
+
+        [Test]
+        public static void CreateFromPointsTest_FourPoint()
+        {
+            Assert.That(nameof(CreateFromPointsTest_FourPoint), Does.StartWith(nameof(RectUtil.CreateFromPoints)));
+
+            Rect rect = RectUtil.CreateFromPoints(new Vector2(1, 2), new Vector2(3, 4), new Vector2(1, 4), new Vector2(3, 2));
+
+            Assert.That(rect.min.x, Is.EqualTo(1));
+            Assert.That(rect.min.y, Is.EqualTo(2));
+            Assert.That(rect.max.x, Is.EqualTo(3));
+            Assert.That(rect.max.y, Is.EqualTo(4));
+
+            rect = RectUtil.CreateFromPoints(new Vector2(3, 4), new Vector2(1, 2), new Vector2(3, 2), new Vector2(1, 4));
 
             Assert.That(rect.min.x, Is.EqualTo(1));
             Assert.That(rect.min.y, Is.EqualTo(2));

--- a/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
@@ -25,5 +25,40 @@ namespace Anvil.Unity.Tests
             Assert.That(rect.max.x, Is.EqualTo(3));
             Assert.That(rect.max.y, Is.EqualTo(4));
         }
+
+        [Test]
+        public static void AbsSizeTest()
+        {
+            Assert.That(nameof(AbsSizeTest), Does.StartWith(nameof(RectUtil.AbsSize)));
+
+            Rect rect_five_five = new Rect(5, 5, 5, 5);
+            Rect rect_negativeFive_negativeFive = new Rect(-5, -5, -5, -5);
+            Rect rect_negativeTen_five = new Rect(-10, -10, 5, 5);
+
+            Assert.That(RectUtil.AbsSize(Rect.zero), Is.EqualTo(Rect.zero));
+            Assert.That(RectUtil.AbsSize(rect_five_five), Is.EqualTo(rect_five_five));
+            Assert.That(RectUtil.AbsSize(rect_negativeFive_negativeFive), Is.EqualTo(rect_negativeTen_five));
+        }
+
+        [Test]
+        public static void AreEquivalentTest()
+        {
+            Assert.That(nameof(AreEquivalentTest), Does.StartWith(nameof(RectUtil.AreEquivalent)));
+
+            Rect rect_five_five = new Rect(5, 5, 5, 5);
+            Rect rect_ten_negativeFive = new Rect(10,10,-5,-5);
+
+            Rect rect_five_six = new Rect(5, 5, 6, 6);
+            Rect rect_six_five = new Rect(6, 6, 5, 5);
+
+            Assert.That(RectUtil.AreEquivalent(rect_five_five, rect_ten_negativeFive), Is.True);
+            Assert.That(RectUtil.AreEquivalent(rect_ten_negativeFive, rect_five_five), Is.True);
+
+            Assert.That(RectUtil.AreEquivalent(rect_five_five, Rect.zero), Is.False);
+            Assert.That(RectUtil.AreEquivalent(rect_ten_negativeFive, Rect.zero), Is.False);
+
+            Assert.That(RectUtil.AreEquivalent(rect_five_five, rect_five_six), Is.False);
+            Assert.That(RectUtil.AreEquivalent(rect_ten_negativeFive, rect_six_five), Is.False);
+        }
     }
 }

--- a/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
@@ -27,18 +27,38 @@ namespace Anvil.Unity.Tests
         }
 
         [Test]
-        public static void CreateFromPointsTest_FourPoint()
+        public static void CreateBoundingRect_FourPoint()
         {
-            Assert.That(nameof(CreateFromPointsTest_FourPoint), Does.StartWith(nameof(RectUtil.CreateFromPoints)));
+            Assert.That(nameof(CreateBoundingRect_FourPoint), Does.StartWith(nameof(RectUtil.CreateBoundingRect)));
 
-            Rect rect = RectUtil.CreateFromPoints(new Vector2(1, 2), new Vector2(3, 4), new Vector2(1, 4), new Vector2(3, 2));
+            Rect rect = RectUtil.CreateBoundingRect(new Vector2(1, 2), new Vector2(3, 4), new Vector2(1, 4), new Vector2(3, 2));
 
             Assert.That(rect.min.x, Is.EqualTo(1));
             Assert.That(rect.min.y, Is.EqualTo(2));
             Assert.That(rect.max.x, Is.EqualTo(3));
             Assert.That(rect.max.y, Is.EqualTo(4));
 
-            rect = RectUtil.CreateFromPoints(new Vector2(3, 4), new Vector2(1, 2), new Vector2(3, 2), new Vector2(1, 4));
+            rect = RectUtil.CreateBoundingRect(new Vector2(3, 4), new Vector2(1, 2), new Vector2(3, 2), new Vector2(1, 4));
+
+            Assert.That(rect.min.x, Is.EqualTo(1));
+            Assert.That(rect.min.y, Is.EqualTo(2));
+            Assert.That(rect.max.x, Is.EqualTo(3));
+            Assert.That(rect.max.y, Is.EqualTo(4));
+        }
+
+        [Test]
+        public static void CreateBoundingRect_NPoint()
+        {
+            Assert.That(nameof(CreateBoundingRect_NPoint), Does.StartWith(nameof(RectUtil.CreateBoundingRect)));
+
+            Rect rect = RectUtil.CreateBoundingRect(new Vector2(1, 2), new Vector2(3, 4), new Vector2(1, 4), new Vector2(3, 2), new Vector2(3, 2));
+
+            Assert.That(rect.min.x, Is.EqualTo(1));
+            Assert.That(rect.min.y, Is.EqualTo(2));
+            Assert.That(rect.max.x, Is.EqualTo(3));
+            Assert.That(rect.max.y, Is.EqualTo(4));
+
+            rect = RectUtil.CreateBoundingRect(new Vector2(1, 4), new Vector2(3, 4), new Vector2(1, 2), new Vector2(3, 2), new Vector2(1, 4));
 
             Assert.That(rect.min.x, Is.EqualTo(1));
             Assert.That(rect.min.y, Is.EqualTo(2));

--- a/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/RectUtilTests.cs
@@ -9,6 +9,8 @@ namespace Anvil.Unity.Tests
         [Test]
         public static void CreateFromPointsTest()
         {
+            Assert.That(nameof(CreateFromPointsTest), Does.StartWith(nameof(RectUtil.CreateFromPoints)));
+
             Rect rect = RectUtil.CreateFromPoints(new Vector2(1, 2), new Vector2(3, 4));
 
             Assert.That(rect.min.x, Is.EqualTo(1));

--- a/Scripts/Runtime/Core/Util/RectUtil.cs
+++ b/Scripts/Runtime/Core/Util/RectUtil.cs
@@ -1,5 +1,6 @@
 
 
+using Unity.Mathematics;
 using UnityEngine;
 
 namespace Anvil.Unity.Core
@@ -46,5 +47,75 @@ namespace Anvil.Unity.Core
 
             return Rect.MinMaxRect(minX, minY, maxX, maxY);
         }
+
+        /// <summary>
+        /// Creates a <see cref="Rect"/> from four arbitrary points
+        /// </summary>
+        /// <param name="point1"></param>
+        /// <param name="point2"></param>
+        /// <param name="point3"></param>
+        /// <param name="point4"></param>
+        /// <returns>A <see cref="Rect"/> containing the four points provided.</returns>
+        public static Rect CreateFromPoints(Vector2 point1, Vector2 point2, Vector2 point3, Vector2 point4)
+        {
+            float4 x = new float4(point1.x, point2.x, point3.x, point4.x);
+            float4 y = new float4(point1.y, point2.y, point3.y, point4.y);
+
+            float minX = math.cmin(x);
+            float minY = math.cmin(y);
+
+            float maxX = math.cmax(x);
+            float maxY = math.cmax(y);
+
+            return Rect.MinMaxRect(minX, minY, maxX, maxY);
+        }
+
+        /// <summary>
+        /// Ensures a <see cref="Rect"/> is expressed in positive width and height values.
+        /// </summary>
+        /// <param name="rect">The <see cref="Rect"/> to evaluate.</param>
+        /// <returns>
+        /// A <see cref="Rect"/> that is equivalent to the provided rectangle but guaranteed to have positive dimensions.
+        /// </returns>
+        /// <remarks>
+        /// The returned <see cref="Rect"/> may or may not be equal but will be equivalent (<see cref="AreEquivalent"/>)
+        /// to the rectangle passed in.
+        /// </remarks>
+        public static Rect AbsSize(Rect rect)
+        {
+            if (rect.width < 0)
+            {
+                (rect.xMin, rect.xMax) = (rect.xMax, rect.xMin);
+            }
+
+            if (rect.height < 0)
+            {
+                (rect.yMin, rect.yMax) = (rect.yMax, rect.yMin);
+            }
+
+            return rect;
+        }
+
+        /// <summary>
+        /// Checks whether two <see cref="Rect"/>s represent the equivalent area.
+        /// </summary>
+        /// <param name="rect1">The first <see cref="Rect"/> the evaluate.</param>
+        /// <param name="rect2">The first <see cref="Rect"/> the evaluate.</param>
+        /// <returns>true if the rectangles are equivalent.</returns>
+        /// <remarks>
+        /// Since the <see cref="Rect"/> object supports negative width/height values two objets could represent the
+        /// same area while not passing an equality check.
+        /// </remarks>
+        public static bool AreEquivalent(Rect rect1, Rect rect2)
+        {
+            rect1 = AbsSize(rect1);
+            rect2 = AbsSize(rect2);
+
+            float4 rect1_float = new float4(rect1.x, rect1.y, rect1.width, rect1.height);
+            float4 rect2_float = new float4(rect2.x, rect2.y, rect2.width, rect2.height);
+
+            return math.all(rect1_float.IsApproximately(rect2_float));
+        }
+
     }
 }


### PR DESCRIPTION
Add additional utilities to `RectUtil`

#### Tag Along
 - Test name assertions for existing tests.

### What is the current behaviour?
Common operations are cumbersome and error prone. These utilities make working with `Rect` a little better.

### What is the new behaviour?
The following utilities were added
 - `AbsSize` - Ensures a `Rect` object has positive width and height values returning an equivalent or equal `Rect`.
 - `AreEquivalent` - Checks whether two provided `Rect` instances represent the same space.
   - Ex: A `Rect(x,y,w,h)` of `(0,0,1,1)` is equivalent to `(1,1,-1,-1)`

(Yes, Unity allows `Rect` to have negative width/height and does not respect this with their provided min/max values)

### What issues does this resolve?
None

### What PRs does this depend on?
 - #96 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
