### PR TITLE
Reset One Time Logs Editor Menu Item

### DIFF
--- a/Scripts/Editor/Logging/OneTimeLoggerEditorMenuItems.cs
+++ b/Scripts/Editor/Logging/OneTimeLoggerEditorMenuItems.cs
@@ -1,0 +1,18 @@
+using Anvil.CSharp.Logging;
+using UnityEditor;
+
+namespace Anvil.Unity.Logging
+{
+    /// <summary>
+    /// Unity Editor menu items related to the <see cref="OneTimeLogger"/>
+    /// </summary>
+    public static class OneTimeLoggerEditorMenuItems
+    {
+        [MenuItem("Anvil/Logging/Reset One Time Logs")]
+        private static void ResetOneTimeLogs()
+        {
+            Log.GetStaticLogger(typeof(OneTimeLoggerEditorMenuItems)).Debug("Resetting one time log filter...");
+            OneTimeLogger.Reset();
+        }
+    }
+}

--- a/Scripts/Editor/Logging/OneTimeLoggerEditorMenuItems.cs.meta
+++ b/Scripts/Editor/Logging/OneTimeLoggerEditorMenuItems.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ddc9aea4f56d41c8b9dc42b7af6e17ae
+timeCreated: 1670616033


### PR DESCRIPTION
Add a menu item to reset the one time logger

### What is the current behaviour?

Short of writing your own code there is no way to easily reset one time log messages in the editor.

### What is the new behaviour?

There is a menu item under `Anvil/Logging/Reset One Time Logs` that, when selected, will reset the state of the one time logger.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None but is complimentary to https://github.com/decline-cookies/anvil-csharp-core/pull/138

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
