### PR TITLE
MathExtension - Add ToString(format) fill

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -668,5 +668,65 @@ namespace Anvil.Unity.Tests
                 );
             Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false, false, true, true)));
         }
+
+        [Test]
+        public static void ToStringTest_float2()
+        {
+            Assert.That(nameof(ToStringTest_float2), Does.StartWith(nameof(MathExtension.ToString)));
+
+            float2 pointFive_negativePointFive = new float2(0.5f, -0.5f);
+
+            Assert.That(pointFive_negativePointFive.ToString(" 000.##;-000.00"), Is.EqualTo("float2( 000.5f, -000.50f)"));
+        }
+
+        [Test]
+        public static void ToStringTest_float3()
+        {
+            Assert.That(nameof(ToStringTest_float3), Does.StartWith(nameof(MathExtension.ToString)));
+
+            float3 pointFive_negativePointFive = new float3(0.5f, -0.5f, 5f);
+
+            Assert.That(pointFive_negativePointFive.ToString(" 000.##;-000.00"), Is.EqualTo("float3( 000.5f, -000.50f,  005f)"));
+        }
+
+        [Test]
+        public static void ToStringTest_float4()
+        {
+            Assert.That(nameof(ToStringTest_float4), Does.StartWith(nameof(MathExtension.ToString)));
+
+            float4 pointFive_negativePointFive = new float4(0.5f, -0.5f, 5f, -5f);
+
+            Assert.That(pointFive_negativePointFive.ToString(" 000.##;-000.00"), Is.EqualTo("float4( 000.5f, -000.50f,  005f, -005.00f)"));
+        }
+
+        [Test]
+        public static void ToStringTest_int2()
+        {
+            Assert.That(nameof(ToStringTest_int2), Does.StartWith(nameof(MathExtension.ToString)));
+
+            int2 pointFive_negativePointFive = new int2(5, -5);
+
+            Assert.That(pointFive_negativePointFive.ToString(" 000;-000"), Is.EqualTo("int2( 005, -005)"));
+        }
+
+        [Test]
+        public static void ToStringTest_int3()
+        {
+            Assert.That(nameof(ToStringTest_int3), Does.StartWith(nameof(MathExtension.ToString)));
+
+            int3 pointFive_negativePointFive = new int3(5, -5, 50);
+
+            Assert.That(pointFive_negativePointFive.ToString(" 000;-000"), Is.EqualTo("int3( 005, -005,  050)"));
+        }
+
+        [Test]
+        public static void ToStringTest_int4()
+        {
+            Assert.That(nameof(ToStringTest_int4), Does.StartWith(nameof(MathExtension.ToString)));
+
+            int4 pointFive_negativePointFive = new int4(5, -5, 50, -50);
+
+            Assert.That(pointFive_negativePointFive.ToString(" 000;-000"), Is.EqualTo("int4( 005, -005,  050, -050)"));
+        }
     }
 }

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Anvil.CSharp.Mathematics;
 using Unity.Mathematics;
@@ -401,6 +402,132 @@ namespace Anvil.Unity.Core
                        math.isnan(a.c1) & math.isnan(b.c1),
                        math.isnan(a.c2) & math.isnan(b.c2),
                        math.isnan(a.c3) & math.isnan(b.c3));
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value using the specified format and current culture.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The format string.
+        /// For valid syntax see:
+        /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers
+        /// </param>
+        /// <returns>The string representation of the value.</returns>
+        /// <remarks>
+        /// This is a fill to match the <see cref="int"/> interface. Unity doesn't define this convenience overload.
+        /// Uses <see cref="NumberFormatInfo.CurrentInfo"/> to get the current culture. This matches the
+        /// <see cref="int"/> implementation.
+        /// https://referencesource.microsoft.com/#mscorlib/system/single.cs,dda909df0f8d2fd0
+        /// </remarks>
+        public static string ToString(this int2 value, string format)
+        {
+            return value.ToString(format, NumberFormatInfo.CurrentInfo);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value using the specified format and current culture.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The format string.
+        /// For valid syntax see:
+        /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers
+        /// </param>
+        /// <returns>The string representation of the value.</returns>
+        /// <remarks>
+        /// This is a fill to match the <see cref="int"/> interface. Unity doesn't define this convenience overload.
+        /// Uses <see cref="NumberFormatInfo.CurrentInfo"/> to get the current culture. This matches the
+        /// <see cref="int"/> implementation.
+        /// https://referencesource.microsoft.com/#mscorlib/system/single.cs,dda909df0f8d2fd0
+        /// </remarks>
+        public static string ToString(this int3 value, string format)
+        {
+            return value.ToString(format, NumberFormatInfo.CurrentInfo);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value using the specified format and current culture.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The format string.
+        /// For valid syntax see:
+        /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers
+        /// </param>
+        /// <returns>The string representation of the value.</returns>
+        /// <remarks>
+        /// This is a fill to match the <see cref="int"/> interface. Unity doesn't define this convenience overload.
+        /// Uses <see cref="NumberFormatInfo.CurrentInfo"/> to get the current culture. This matches the
+        /// <see cref="int"/> implementation.
+        /// https://referencesource.microsoft.com/#mscorlib/system/single.cs,dda909df0f8d2fd0
+        /// </remarks>
+        public static string ToString(this int4 value, string format)
+        {
+            return value.ToString(format, NumberFormatInfo.CurrentInfo);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value using the specified format and current culture.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The format string.
+        /// For valid syntax see:
+        /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers
+        /// </param>
+        /// <returns>The string representation of the value.</returns>
+        /// <remarks>
+        /// This is a fill to match the <see cref="float"/> interface. Unity doesn't define this convenience overload.
+        /// Uses <see cref="NumberFormatInfo.CurrentInfo"/> to get the current culture. This matches the
+        /// <see cref="float"/> implementation.
+        /// https://referencesource.microsoft.com/#mscorlib/system/single.cs,dda909df0f8d2fd0
+        /// </remarks>
+        public static string ToString(this float2 value, string format)
+        {
+            return value.ToString(format, NumberFormatInfo.CurrentInfo);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value using the specified format and current culture.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The format string.
+        /// For valid syntax see:
+        /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers
+        /// </param>
+        /// <returns>The string representation of the value.</returns>
+        /// <remarks>
+        /// This is a fill to match the <see cref="float"/> interface. Unity doesn't define this convenience overload.
+        /// Uses <see cref="NumberFormatInfo.CurrentInfo"/> to get the current culture. This matches the
+        /// <see cref="float"/> implementation.
+        /// https://referencesource.microsoft.com/#mscorlib/system/single.cs,dda909df0f8d2fd0
+        /// </remarks>
+        public static string ToString(this float3 value, string format)
+        {
+            return value.ToString(format, NumberFormatInfo.CurrentInfo);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value using the specified format and current culture.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">
+        /// The format string.
+        /// For valid syntax see:
+        /// https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers
+        /// </param>
+        /// <returns>The string representation of the value.</returns>
+        /// <remarks>
+        /// This is a fill to match the <see cref="float"/> interface. Unity doesn't define this convenience overload.
+        /// Uses <see cref="NumberFormatInfo.CurrentInfo"/> to get the current culture. This matches the
+        /// <see cref="float"/> implementation.
+        /// https://referencesource.microsoft.com/#mscorlib/system/single.cs,dda909df0f8d2fd0
+        /// </remarks>
+        public static string ToString(this float4 value, string format)
+        {
+            return value.ToString(format, NumberFormatInfo.CurrentInfo);
         }
     }
 }


### PR DESCRIPTION
Add a `ToString(string format)` extension to `float2/3/4` and `int2/3/4`.
Unity does not supply the convenience override that exists on the built in `float` and `int` types.

### What is the current behaviour?

When converting the types described above to string with custom formatting a formatter must be supplied.

### What is the new behaviour?

The formatter no longer needs to be supplied with a format string. The current cultural formatter will be used.
This matches the behaviour of `float.ToString(string)` and `int.ToString(string)`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
