### PR TITLE
UnityLogHandler - Highlight log qualifier slightly

### DIFF
--- a/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogHandler.cs
@@ -14,9 +14,12 @@ namespace Anvil.Unity.Logging
     {
         public const uint PRIORITY = ConsoleLogHandler.PRIORITY + 10;
 
-        protected override string DefaultLogFormat =>
-            $"({LOG_PART_CALLER_TYPE}.{LOG_PART_CALLER_METHOD}) {LOG_PART_MESSAGE}\n" +
-            $"(at {LOG_PART_CALLER_FILE}:{LOG_PART_CALLER_LINE})";
+        protected override string DefaultLogFormat
+        {
+            get =>
+                $"<color=#DDDDDD>({LOG_PART_CALLER_TYPE}.{LOG_PART_CALLER_METHOD})</color> {LOG_PART_MESSAGE}\n" +
+                $"(at {LOG_PART_CALLER_FILE}:{LOG_PART_CALLER_LINE})";
+        }
 
         protected override void HandleFormattedLog(LogLevel level, string formattedLog)
         {

--- a/Scripts/Runtime/Logging/anvil-unity-logging.dll
+++ b/Scripts/Runtime/Logging/anvil-unity-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec2885f4d88dc97ffbcc3066d333cc7042e37ff6bdcd9864c045b307c50de7e7
+oid sha256:72312523cb6f7b955a00d2182dbc5926f98c475966014eb3ee9269da92d23ce1
 size 12800


### PR DESCRIPTION
The type/method qualifier on logs in unity are now highlighted with a lightly brighter white treatment.

![image](https://user-images.githubusercontent.com/1426795/209217859-d62cf06c-c19c-48da-9df4-678b9db61407.png)

![image](https://user-images.githubusercontent.com/1426795/209217895-8fdbbfa3-3543-4da0-b376-4d1c2aac7951.png)

### What is the current behaviour?

Type/method qualifier is the same as color as the rest of the log.

### What is the new behaviour?

Type/method qualifier is a brighter white to help it stand out next to the log message.
Also converted `DefaultLogFormat` getter to match the getter convention in the rest of Anvil.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
