### PR TITLE
AbstractAnvilUnityApplication - Call base.Awake

### DIFF
--- a/Scripts/Runtime/Core/AbstractAnvilUnityApplication.cs
+++ b/Scripts/Runtime/Core/AbstractAnvilUnityApplication.cs
@@ -41,6 +41,8 @@ namespace Anvil.Unity.Core
         //Sealing to ensure inheriting classes can't override this behaviour
         protected sealed override void Awake()
         {
+            base.Awake();
+
             Application.quitting += Application_Quitting;
             InitDontDestroyOnLoadGameObjects();
             Init();


### PR DESCRIPTION
Call `base.Awake()` in `AbstractAnvilUnityAppication`'s ``Awake` override.

### What is the current behaviour?

`base.Awake()` is not called so serializable fields are not validated.

### What is the new behaviour?

`base.Awake()` is called

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
