### PR TITLE
Issue #107 - Editor Menu Tool to Toggle Script Defines

### DIFF
--- a/Scripts/Editor/Debug.meta
+++ b/Scripts/Editor/Debug.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 75c6c6ec76014d62990d6860c12fe40c
+timeCreated: 1673964055

--- a/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs
+++ b/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs
@@ -1,0 +1,68 @@
+using UnityEditor;
+
+namespace Anvil.Unity.Editor.Debug
+{
+    /// <summary>
+    /// Sets up script defines for common Anvil specific script defines
+    /// </summary>
+    public static class AnvilDebugSafetyScriptDefines
+    {
+        /// <summary>
+        /// Script Define for code safety checks.
+        /// Should not be performance intensive.
+        /// </summary>
+        public const string ANVIL_DEBUG_SAFETY = "ANVIL_DEBUG_SAFETY";
+        
+        /// <summary>
+        /// Script Define for code safety checks that are expensive to determine.
+        /// </summary>
+        public const string ANVIL_DEBUG_SAFETY_EXPENSIVE = "ANVIL_DEBUG_SAFETY_EXPENSIVE";
+        
+        
+        private const string ANVIL_DEBUG_SAFETY_MENU_PATH = ScriptDefinesToggle.MENU_PATH_BASE + "/" + ANVIL_DEBUG_SAFETY;
+        private const string ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH = ScriptDefinesToggle.MENU_PATH_BASE + "/" + ANVIL_DEBUG_SAFETY_EXPENSIVE;
+
+        //For ANVIL_DEBUG_SAFETY, we don't require anything to turn it on, but we need to ensure that ANVIL_DEBUG_SAFETY_EXPENSIVE is turned off if we are off
+        private static readonly ScriptDefineDefinition ANVIL_DEBUG_SAFETY_DEFINITION = new ScriptDefineDefinition(ANVIL_DEBUG_SAFETY,
+                                                                                                                  ANVIL_DEBUG_SAFETY_MENU_PATH,
+                                                                                                                  null,
+                                                                                                                  new[]
+                                                                                                                  {
+                                                                                                                      ANVIL_DEBUG_SAFETY_EXPENSIVE
+                                                                                                                  });
+
+        //For ANVIL_DEBUG_SAFETY_EXPENSIVE, we require ANVIL_DEBUG_SAFETY to be on if we're on, but we don't need to turn anything off if we turn off
+        private static readonly ScriptDefineDefinition ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION = new ScriptDefineDefinition(ANVIL_DEBUG_SAFETY_EXPENSIVE,
+                                                                                                                            ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH,
+                                                                                                                            new[]
+                                                                                                                            {
+                                                                                                                                ANVIL_DEBUG_SAFETY
+                                                                                                                            },
+                                                                                                                            null);
+
+
+        [MenuItem(ANVIL_DEBUG_SAFETY_MENU_PATH, true)]
+        private static bool Toggle_Validator_Safety()
+        {
+            return ScriptDefinesToggle.Toggle_Validator(ANVIL_DEBUG_SAFETY_DEFINITION);
+        }
+
+        [MenuItem(ANVIL_DEBUG_SAFETY_MENU_PATH)]
+        private static void Toggle_Safety()
+        {
+            ScriptDefinesToggle.Toggle(ANVIL_DEBUG_SAFETY_DEFINITION);
+        }
+
+        [MenuItem(ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH, true)]
+        private static bool Toggle_Validator_Safety_Expensive()
+        {
+            return ScriptDefinesToggle.Toggle_Validator(ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION);
+        }
+
+        [MenuItem(ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH)]
+        private static void Toggle_Safety_Expensive()
+        {
+            ScriptDefinesToggle.Toggle(ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION);
+        }
+    }
+}

--- a/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs
+++ b/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs
@@ -13,13 +13,13 @@ namespace Anvil.Unity.Editor.Debug
         /// Should not be performance intensive.
         /// </summary>
         public const string ANVIL_DEBUG_SAFETY = "ANVIL_DEBUG_SAFETY";
-        
+
         /// <summary>
         /// Script Define for code safety checks that are expensive to determine.
         /// </summary>
         public const string ANVIL_DEBUG_SAFETY_EXPENSIVE = "ANVIL_DEBUG_SAFETY_EXPENSIVE";
-        
-        
+
+
         private const string ANVIL_DEBUG_SAFETY_MENU_PATH = ScriptDefinesToggle.MENU_PATH_BASE + "/" + ANVIL_DEBUG_SAFETY;
         private const string ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH = ScriptDefinesToggle.MENU_PATH_BASE + "/" + ANVIL_DEBUG_SAFETY_EXPENSIVE;
 
@@ -48,28 +48,28 @@ namespace Anvil.Unity.Editor.Debug
         }
 
 
-        [MenuItem(ANVIL_DEBUG_SAFETY_MENU_PATH, true)]
-        private static bool Toggle_Validator_Safety()
-        {
-            return ScriptDefinesToggle.Toggle_Validator(ANVIL_DEBUG_SAFETY_DEFINITION);
-        }
-
         [MenuItem(ANVIL_DEBUG_SAFETY_MENU_PATH)]
         private static void Toggle_Safety()
         {
             ScriptDefinesToggle.Toggle(ANVIL_DEBUG_SAFETY_DEFINITION);
         }
 
-        [MenuItem(ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH, true)]
-        private static bool Toggle_Validator_Safety_Expensive()
+        [MenuItem(ANVIL_DEBUG_SAFETY_MENU_PATH, true)]
+        private static bool Toggle_Safety_Validator()
         {
-            return ScriptDefinesToggle.Toggle_Validator(ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION);
+            return ScriptDefinesToggle.Toggle_Validator(ANVIL_DEBUG_SAFETY_DEFINITION);
         }
 
         [MenuItem(ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH)]
         private static void Toggle_Safety_Expensive()
         {
             ScriptDefinesToggle.Toggle(ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION);
+        }
+
+        [MenuItem(ANVIL_DEBUG_SAFETY_EXPENSIVE_MENU_PATH, true)]
+        private static bool Toggle_Safety_Expensive_Validator()
+        {
+            return ScriptDefinesToggle.Toggle_Validator(ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION);
         }
     }
 }

--- a/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs
+++ b/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs
@@ -5,6 +5,7 @@ namespace Anvil.Unity.Editor.Debug
     /// <summary>
     /// Sets up script defines for common Anvil specific script defines
     /// </summary>
+    [InitializeOnLoad]
     public static class AnvilDebugSafetyScriptDefines
     {
         /// <summary>
@@ -39,6 +40,12 @@ namespace Anvil.Unity.Editor.Debug
                                                                                                                                 ANVIL_DEBUG_SAFETY
                                                                                                                             },
                                                                                                                             null);
+
+        static AnvilDebugSafetyScriptDefines()
+        {
+            ScriptDefinesToggle.RegisterScriptDefineDefinition(ANVIL_DEBUG_SAFETY_DEFINITION);
+            ScriptDefinesToggle.RegisterScriptDefineDefinition(ANVIL_DEBUG_SAFETY_EXPENSIVE_DEFINITION);
+        }
 
 
         [MenuItem(ANVIL_DEBUG_SAFETY_MENU_PATH, true)]

--- a/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs.meta
+++ b/Scripts/Editor/Debug/AnvilDebugSafetyScriptDefines.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 28b331d498364c8ca3018cfce0bd0dd7
+timeCreated: 1673965609

--- a/Scripts/Editor/Debug/ScriptDefineDefinition.cs
+++ b/Scripts/Editor/Debug/ScriptDefineDefinition.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Anvil.Unity.Editor.Debug
+{
+    /// <summary>
+    /// Defines information for use with a Script Define and the behaviour when toggling on and off.
+    /// <see cref="ScriptDefinesToggle"/>
+    /// </summary>
+    public class ScriptDefineDefinition
+    {
+        internal string Define { get; }
+        internal string MenuPath { get; }
+        internal HashSet<string> RequiredDefines { get; }
+        internal HashSet<string> DependentDefines { get; }
+
+        public ScriptDefineDefinition(string define, string menuPath, IEnumerable<string> requiredDefines, IEnumerable<string> dependentDefines)
+        {
+            Define = define;
+            MenuPath = menuPath;
+            RequiredDefines = requiredDefines != null ? requiredDefines.ToHashSet() : new HashSet<string>();
+            DependentDefines = dependentDefines != null ? dependentDefines.ToHashSet() : new HashSet<string>();
+        }
+
+        internal void MergeIn(ScriptDefineDefinition other)
+        {
+            int requiredCount = RequiredDefines.Count;
+            int dependentCount = DependentDefines.Count;
+            RequiredDefines.UnionWith(other.RequiredDefines);
+            DependentDefines.UnionWith(other.DependentDefines);
+            
+            //If something changed we should validate it's safe
+            if (RequiredDefines.Count == requiredCount
+             && DependentDefines.Count == dependentCount)
+            {
+                return;
+            }
+
+            HashSet<string> dupes = new HashSet<string>(RequiredDefines);
+            dupes.IntersectWith(DependentDefines);
+            if (dupes.Count == 0)
+            {
+                return;
+            }
+
+            throw new InvalidOperationException($"Circular reference detected! The script define {Define} requires and depends on {string.Join("," , dupes)}. Please check your {nameof(ScriptDefineDefinition)}s to ensure you have set them up properly.");
+        }
+    }
+}

--- a/Scripts/Editor/Debug/ScriptDefineDefinition.cs
+++ b/Scripts/Editor/Debug/ScriptDefineDefinition.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +5,7 @@ namespace Anvil.Unity.Editor.Debug
 {
     /// <summary>
     /// Defines information for use with a Script Define and the behaviour when toggling on and off.
-    /// <see cref="ScriptDefinesToggle"/>
+    /// See: <see cref="ScriptDefinesToggle"/>
     /// </summary>
     public class ScriptDefineDefinition
     {
@@ -26,8 +25,12 @@ namespace Anvil.Unity.Editor.Debug
         {
             Define = define;
             MenuPath = menuPath;
-            RequiredDefines = requiredDefines != null ? requiredDefines.ToHashSet() : new HashSet<string>();
-            DependentDefines = dependentDefines != null ? dependentDefines.ToHashSet() : new HashSet<string>();
+            RequiredDefines = requiredDefines != null
+                ? requiredDefines.ToHashSet()
+                : new HashSet<string>();
+            DependentDefines = dependentDefines != null
+                ? dependentDefines.ToHashSet()
+                : new HashSet<string>();
         }
     }
 }

--- a/Scripts/Editor/Debug/ScriptDefineDefinition.cs
+++ b/Scripts/Editor/Debug/ScriptDefineDefinition.cs
@@ -15,36 +15,19 @@ namespace Anvil.Unity.Editor.Debug
         internal HashSet<string> RequiredDefines { get; }
         internal HashSet<string> DependentDefines { get; }
 
+        /// <summary>
+        /// Creates a new <see cref="ScriptDefineDefinition"/> instance.
+        /// </summary>
+        /// <param name="define">The Script Define to add/remove to/from PlayerSettings</param>
+        /// <param name="menuPath">The path to show in the menu for toggling on and off. <see cref="ScriptDefinesToggle.MENU_PATH_BASE"/></param>
+        /// <param name="requiredDefines">Script Defines that are required to be set in order for this to be set.</param>
+        /// <param name="dependentDefines">Script Defines that require this to be set.</param>
         public ScriptDefineDefinition(string define, string menuPath, IEnumerable<string> requiredDefines, IEnumerable<string> dependentDefines)
         {
             Define = define;
             MenuPath = menuPath;
             RequiredDefines = requiredDefines != null ? requiredDefines.ToHashSet() : new HashSet<string>();
             DependentDefines = dependentDefines != null ? dependentDefines.ToHashSet() : new HashSet<string>();
-        }
-
-        internal void MergeIn(ScriptDefineDefinition other)
-        {
-            int requiredCount = RequiredDefines.Count;
-            int dependentCount = DependentDefines.Count;
-            RequiredDefines.UnionWith(other.RequiredDefines);
-            DependentDefines.UnionWith(other.DependentDefines);
-            
-            //If something changed we should validate it's safe
-            if (RequiredDefines.Count == requiredCount
-             && DependentDefines.Count == dependentCount)
-            {
-                return;
-            }
-
-            HashSet<string> dupes = new HashSet<string>(RequiredDefines);
-            dupes.IntersectWith(DependentDefines);
-            if (dupes.Count == 0)
-            {
-                return;
-            }
-
-            throw new InvalidOperationException($"Circular reference detected! The script define {Define} requires and depends on {string.Join("," , dupes)}. Please check your {nameof(ScriptDefineDefinition)}s to ensure you have set them up properly.");
         }
     }
 }

--- a/Scripts/Editor/Debug/ScriptDefineDefinition.cs.meta
+++ b/Scripts/Editor/Debug/ScriptDefineDefinition.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0b1b8ec667b347daba328bd3be177774
+timeCreated: 1673969384

--- a/Scripts/Editor/Debug/ScriptDefinesToggle.cs
+++ b/Scripts/Editor/Debug/ScriptDefinesToggle.cs
@@ -1,7 +1,10 @@
+using Anvil.CSharp.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Build;
+using UnityEditor.Callbacks;
 
 namespace Anvil.Unity.Editor.Debug
 {
@@ -15,17 +18,132 @@ namespace Anvil.Unity.Editor.Debug
         /// The base location for where items should appear in the menu.
         /// </summary>
         public const string MENU_PATH_BASE = "Anvil/Script Defines";
-        
+
         private static readonly NamedBuildTarget NAMED_BUILD_TARGET;
         private static readonly Dictionary<string, ScriptDefineDefinition> SCRIPT_DEFINE_DEFINITIONS_LOOKUP;
+        private static readonly Logger LOGGER;
 
         static ScriptDefinesToggle()
         {
+            LOGGER = Log.GetStaticLogger(typeof(ScriptDefinesToggle));
             SCRIPT_DEFINE_DEFINITIONS_LOOKUP = new Dictionary<string, ScriptDefineDefinition>();
-            
+
             BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
             BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
             NAMED_BUILD_TARGET = NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
+        }
+
+        [DidReloadScripts]
+        private static void ValidateSafety()
+        {
+            PlayerSettings.GetScriptingDefineSymbols(NAMED_BUILD_TARGET, out string[] defines);
+            HashSet<string> definesHashSet = defines.ToHashSet();
+
+            foreach (ScriptDefineDefinition scriptDefineDefinition in SCRIPT_DEFINE_DEFINITIONS_LOOKUP.Values)
+            {
+                ValidateForErrors(scriptDefineDefinition);
+                //If we're not active we don't need to check our requirements
+                if (!definesHashSet.Contains(scriptDefineDefinition.Define))
+                {
+                    continue;
+                }
+                
+                //Ensure that our requirements are present in case some other script or the developer manually removed them
+                foreach (string define in scriptDefineDefinition.RequiredDefines.Where(define => !definesHashSet.Contains(define)))
+                {
+                    LOGGER.Error($"{scriptDefineDefinition.Define} requires that {define} is set, but it's not present! Removing {scriptDefineDefinition.Define} and all dependencies if they were set.");
+                    RemoveDependentDefines(scriptDefineDefinition, definesHashSet);
+                    PlayerSettings.SetScriptingDefineSymbols(NAMED_BUILD_TARGET, definesHashSet.ToArray());
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Registers a <see cref="ScriptDefineDefinition"/> so that the editor is aware of requirements and dependencies
+        /// for a specific Script Define
+        /// </summary>
+        /// <param name="scriptDefineDefinition">The <see cref="ScriptDefineDefinition"/> to register.</param>
+        public static void RegisterScriptDefineDefinition(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            //Get the cached Script Define Definition if it exists, otherwise make sure it's added 
+            //We now have our ground truth
+            ScriptDefineDefinition cachedScriptDefineDefinition = GetOrRegisterCachedScriptDefineDefinition(scriptDefineDefinition);
+
+            //We want to create script definitions for all our requirements and dependencies as well if they don't exist
+            EnsureRelatedScriptDefineDefinitionsAreCreated(scriptDefineDefinition);
+
+            //Ensure that all Script Define Definitions know about each other
+            UpdateRelationships(cachedScriptDefineDefinition, scriptDefineDefinition);
+        }
+
+        private static ScriptDefineDefinition GetOrRegisterCachedScriptDefineDefinition(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            if (!SCRIPT_DEFINE_DEFINITIONS_LOOKUP.TryGetValue(scriptDefineDefinition.Define, out ScriptDefineDefinition cachedScriptDefineDefinition))
+            {
+                cachedScriptDefineDefinition = scriptDefineDefinition;
+                SCRIPT_DEFINE_DEFINITIONS_LOOKUP.Add(cachedScriptDefineDefinition.Define, cachedScriptDefineDefinition);
+            }
+
+            return cachedScriptDefineDefinition;
+        }
+
+        private static ScriptDefineDefinition GetCachedScriptDefineDefinition(string define)
+        {
+            if (!SCRIPT_DEFINE_DEFINITIONS_LOOKUP.TryGetValue(define, out ScriptDefineDefinition scriptDefineDefinition))
+            {
+                throw new InvalidOperationException($"Trying to get Script Define Definition for {define} but it doesn't exist! Did you call {nameof(ScriptDefinesToggle.RegisterScriptDefineDefinition)}?");
+            }
+
+            return scriptDefineDefinition;
+        }
+
+        private static void EnsureRelatedScriptDefineDefinitionsAreCreated(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            EnsureRelatedScriptDefineDefinitionsAreCreated(scriptDefineDefinition.RequiredDefines);
+            EnsureRelatedScriptDefineDefinitionsAreCreated(scriptDefineDefinition.DependentDefines);
+        }
+
+        private static void EnsureRelatedScriptDefineDefinitionsAreCreated(HashSet<string> relatedDefines)
+        {
+            foreach (string define in relatedDefines)
+            {
+                if (SCRIPT_DEFINE_DEFINITIONS_LOOKUP.TryGetValue(define, out ScriptDefineDefinition relatedScriptDefineDefinition))
+                {
+                    continue;
+                }
+
+                relatedScriptDefineDefinition = new ScriptDefineDefinition(define,
+                                                                           null,
+                                                                           null,
+                                                                           null);
+                SCRIPT_DEFINE_DEFINITIONS_LOOKUP.Add(define, relatedScriptDefineDefinition);
+            }
+        }
+
+        private static void ValidateForErrors(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            string[] dupes = scriptDefineDefinition.DependentDefines.Intersect(scriptDefineDefinition.RequiredDefines).ToArray();
+            if (dupes.Any())
+            {
+                throw new InvalidOperationException($"Circular reference detected! The script define {scriptDefineDefinition.Define} requires and depends on {string.Join("," , dupes)}. Please check your {nameof(ScriptDefineDefinition)}s to ensure you have set them up properly.");
+            }
+        }
+
+        private static void UpdateRelationships(ScriptDefineDefinition cachedScriptDefineDefinition, ScriptDefineDefinition incomingScriptDefineDefinition)
+        {
+            foreach (string define in incomingScriptDefineDefinition.RequiredDefines)
+            {
+                cachedScriptDefineDefinition.RequiredDefines.Add(define);
+                ScriptDefineDefinition requiredDefineDefinition = SCRIPT_DEFINE_DEFINITIONS_LOOKUP[define];
+                requiredDefineDefinition.DependentDefines.Add(cachedScriptDefineDefinition.Define);
+            }
+
+            foreach (string define in incomingScriptDefineDefinition.DependentDefines)
+            {
+                cachedScriptDefineDefinition.DependentDefines.Add(define);
+                ScriptDefineDefinition dependentDefineDefinition = SCRIPT_DEFINE_DEFINITIONS_LOOKUP[define];
+                dependentDefineDefinition.RequiredDefines.Add(cachedScriptDefineDefinition.Define);
+            }
         }
         
         /// <summary>
@@ -51,49 +169,48 @@ namespace Anvil.Unity.Editor.Debug
         {
             //App level script defines may require framework level script defines to be turned on, this ensures
             //that we get a project consolidated view of what to turn on/off
-            scriptDefineDefinition = GetMergedScriptDefineDefinition(scriptDefineDefinition);
+            scriptDefineDefinition = GetCachedScriptDefineDefinition(scriptDefineDefinition.Define);
             
             PlayerSettings.GetScriptingDefineSymbols(NAMED_BUILD_TARGET, out string[] defines);
             HashSet<string> definesHashSet = defines.ToHashSet();
-            
+
             //If the define is already turned on
             if (definesHashSet.Contains(scriptDefineDefinition.Define))
             {
+                LOGGER.Debug($"Removing {scriptDefineDefinition.Define} and all dependencies if they were set.");
                 //Turn it off as well as everything that depends on it
-                definesHashSet.Remove(scriptDefineDefinition.Define);
-                foreach (string dependentDefine in scriptDefineDefinition.DependentDefines)
-                {
-                    definesHashSet.Remove(dependentDefine);
-                }
+                RemoveDependentDefines(scriptDefineDefinition, definesHashSet);
             }
             else
             {
+                LOGGER.Debug($"Adding {scriptDefineDefinition.Define} and all requirements if not already set.");
                 //Turn it on as well as everything that it requires
-                definesHashSet.Add(scriptDefineDefinition.Define);
-                foreach (string requiredDefine in scriptDefineDefinition.RequiredDefines)
-                {
-                    definesHashSet.Add(requiredDefine);
-                }
+                AddRequiredDefines(scriptDefineDefinition, definesHashSet);
             }
 
             PlayerSettings.SetScriptingDefineSymbols(NAMED_BUILD_TARGET, definesHashSet.ToArray());
         }
 
-        private static ScriptDefineDefinition GetMergedScriptDefineDefinition(ScriptDefineDefinition scriptDefineDefinition)
+        private static void RemoveDependentDefines(ScriptDefineDefinition scriptDefineDefinition, HashSet<string> definesHashSet)
         {
-            //If we've never seen this before, we'll take this as the ground truth.
-            if (!SCRIPT_DEFINE_DEFINITIONS_LOOKUP.TryGetValue(scriptDefineDefinition.Define, out ScriptDefineDefinition cachedScriptDefineDefinition))
+            //Remove ourself
+            definesHashSet.Remove(scriptDefineDefinition.Define);
+            //Recursively remove any other dependencies
+            foreach (ScriptDefineDefinition dependentDefineDefinition in scriptDefineDefinition.DependentDefines.Select(GetCachedScriptDefineDefinition))
             {
-                cachedScriptDefineDefinition = scriptDefineDefinition;
-                SCRIPT_DEFINE_DEFINITIONS_LOOKUP.Add(scriptDefineDefinition.Define, cachedScriptDefineDefinition);
+                RemoveDependentDefines(dependentDefineDefinition, definesHashSet);
             }
-            //Otherwise we will merge the incoming definitions requirements with ours to allow other assemblies to require/depend on our defines
-            else
+        }
+        
+        private static void AddRequiredDefines(ScriptDefineDefinition scriptDefineDefinition, HashSet<string> definesHashSet)
+        {
+            //Add ourself
+            definesHashSet.Add(scriptDefineDefinition.Define);
+            //Recursively add any other requirements
+            foreach (ScriptDefineDefinition requiredDefineDefinition in scriptDefineDefinition.RequiredDefines.Select(GetCachedScriptDefineDefinition))
             {
-                cachedScriptDefineDefinition.MergeIn(scriptDefineDefinition);
+                AddRequiredDefines(requiredDefineDefinition, definesHashSet);
             }
-            
-            return cachedScriptDefineDefinition;
         }
     }
 }

--- a/Scripts/Editor/Debug/ScriptDefinesToggle.cs
+++ b/Scripts/Editor/Debug/ScriptDefinesToggle.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+
+namespace Anvil.Unity.Editor.Debug
+{
+    /// <summary>
+    /// Editor helper class to easily toggle on and off Script Defines and their dependencies.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class ScriptDefinesToggle
+    {
+        /// <summary>
+        /// The base location for where items should appear in the menu.
+        /// </summary>
+        public const string MENU_PATH_BASE = "Anvil/Script Defines";
+        
+        private static readonly NamedBuildTarget NAMED_BUILD_TARGET;
+        private static readonly Dictionary<string, ScriptDefineDefinition> SCRIPT_DEFINE_DEFINITIONS_LOOKUP;
+
+        static ScriptDefinesToggle()
+        {
+            SCRIPT_DEFINE_DEFINITIONS_LOOKUP = new Dictionary<string, ScriptDefineDefinition>();
+            
+            BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
+            BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+            NAMED_BUILD_TARGET = NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
+        }
+        
+        /// <summary>
+        /// Validator function to show if a given Script Define is currently enabled or not.
+        /// Call this to validate a Script Define menu item.
+        /// </summary>
+        /// <param name="scriptDefineDefinition">The <see cref="ScriptDefineDefinition"/> representing the define</param>
+        /// <returns>True as Script Defines can be toggled at any time</returns>
+        public static bool Toggle_Validator(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            PlayerSettings.GetScriptingDefineSymbols(NAMED_BUILD_TARGET, out string[] defines);
+            bool isEnabled = defines.Contains(scriptDefineDefinition.Define);
+            Menu.SetChecked(scriptDefineDefinition.MenuPath, isEnabled);
+            return true;
+        }
+        
+        /// <summary>
+        /// Toggle function to turn on or off a given Script Define.
+        /// Call this to toggle a Script Define from the menu.
+        /// </summary>
+        /// <param name="scriptDefineDefinition">The <see cref="ScriptDefineDefinition"/> representing the define</param>
+        public static void Toggle(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            //App level script defines may require framework level script defines to be turned on, this ensures
+            //that we get a project consolidated view of what to turn on/off
+            scriptDefineDefinition = GetMergedScriptDefineDefinition(scriptDefineDefinition);
+            
+            PlayerSettings.GetScriptingDefineSymbols(NAMED_BUILD_TARGET, out string[] defines);
+            HashSet<string> definesHashSet = defines.ToHashSet();
+            
+            //If the define is already turned on
+            if (definesHashSet.Contains(scriptDefineDefinition.Define))
+            {
+                //Turn it off as well as everything that depends on it
+                definesHashSet.Remove(scriptDefineDefinition.Define);
+                foreach (string dependentDefine in scriptDefineDefinition.DependentDefines)
+                {
+                    definesHashSet.Remove(dependentDefine);
+                }
+            }
+            else
+            {
+                //Turn it on as well as everything that it requires
+                definesHashSet.Add(scriptDefineDefinition.Define);
+                foreach (string requiredDefine in scriptDefineDefinition.RequiredDefines)
+                {
+                    definesHashSet.Add(requiredDefine);
+                }
+            }
+
+            PlayerSettings.SetScriptingDefineSymbols(NAMED_BUILD_TARGET, definesHashSet.ToArray());
+        }
+
+        private static ScriptDefineDefinition GetMergedScriptDefineDefinition(ScriptDefineDefinition scriptDefineDefinition)
+        {
+            //If we've never seen this before, we'll take this as the ground truth.
+            if (!SCRIPT_DEFINE_DEFINITIONS_LOOKUP.TryGetValue(scriptDefineDefinition.Define, out ScriptDefineDefinition cachedScriptDefineDefinition))
+            {
+                cachedScriptDefineDefinition = scriptDefineDefinition;
+                SCRIPT_DEFINE_DEFINITIONS_LOOKUP.Add(scriptDefineDefinition.Define, cachedScriptDefineDefinition);
+            }
+            //Otherwise we will merge the incoming definitions requirements with ours to allow other assemblies to require/depend on our defines
+            else
+            {
+                cachedScriptDefineDefinition.MergeIn(scriptDefineDefinition);
+            }
+            
+            return cachedScriptDefineDefinition;
+        }
+    }
+}

--- a/Scripts/Editor/Debug/ScriptDefinesToggle.cs.meta
+++ b/Scripts/Editor/Debug/ScriptDefinesToggle.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dca41e031f604f9ca85c8dd8c49a0ade
+timeCreated: 1673964084


### PR DESCRIPTION
Moved from https://github.com/decline-cookies/anvil-unity-dots/issues/106 and https://github.com/decline-cookies/anvil-unity-dots/pull/110

This is a simple tool to allow for quickly toggling Script Defines. 

### What is the current behaviour?

- You have to remember what Script Defines are available
- You have to manually add/remove them from the project settings and spell them correctly
- You have to remember what other Script Defines are allowed to be on or off. 

### What is the new behaviour?

- You can simply go to the menu item and select the script define you want to turn on or off (Status is conveyed)
- If the script define requires any other script defines to be on, they will also be turned on.
- If the script define has any other script defines that depend on it, they will also be turned off.
- The ability for downstream script defines (ex. custom safety for a piece of the project) to merge in nicely with existing framework level script defines. 
    - Ex. PATHFINDING_SAFETY requires that ANVIL_DEBUG_SAFETY is also on. ANVIL_DEBUG_SAFETY doesn't know anything about PATHFINDING_SAFETY but that's ok.  
    - When PATHFINDING_SAFETY is turned on, ANVIL_DEBUG_SAFETY will also be turned on.
    - When ANVIL_DEBUG_SAFETY is turned off, PATHFINDING_SAFETY will also be turned off.
- Added two ANVIL level script defines
    - ANVIL_DEBUG_SAFETY - General safety checks, not performance intensive
    - ANVIL_DEBUG_SAFETY_EXPENSIVE - Safety checks that are performance intensive to calculate.

### What issues does this resolve?
- Resolves #107 

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes
 - [ ] No
