### PR TITLE
Add MathExtension Color to Float Conversion

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -25,7 +25,7 @@ namespace Anvil.Unity.Tests
             Assert.That(new float3(-1f).GetInverse(), Is.EqualTo(new float3(-1f)));
             Assert.That(new float3(-2f).GetInverse(), Is.EqualTo(new float3(-0.5f)));
 
-            Assert.That(new float3(7f, -2f, 0f).GetInverse(), Is.EqualTo(new float3(1f/7f, -0.5f, float.PositiveInfinity)));
+            Assert.That(new float3(7f, -2f, 0f).GetInverse(), Is.EqualTo(new float3(1f / 7f, -0.5f, float.PositiveInfinity)));
 
             Assert.That(float3.zero.GetInverse(), Is.EqualTo(new float3(float.PositiveInfinity)));
             Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN).GetInverse(), Is.EqualTo(new float3(0, 0, float.NaN)).Using<float3>(EqualityWithNaN));
@@ -43,7 +43,7 @@ namespace Anvil.Unity.Tests
             Assert.That(new float3(-1f).GetInverseSafe(), Is.EqualTo(new float3(-1f)));
             Assert.That(new float3(-2f).GetInverseSafe(), Is.EqualTo(new float3(-0.5f)));
 
-            Assert.That(new float3(7f, -2f, 0f).GetInverseSafe(), Is.EqualTo(new float3(1f/7f, -0.5f, 0f)));
+            Assert.That(new float3(7f, -2f, 0f).GetInverseSafe(), Is.EqualTo(new float3(1f / 7f, -0.5f, 0f)));
 
             Assert.That(float3.zero.GetInverseSafe(), Is.EqualTo(float3.zero));
             Assert.That(new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN).GetInverseSafe(), Is.EqualTo(new float3(0, 0, 0f)));
@@ -66,8 +66,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one - float.Epsilon), Is.True);
             Assert.That(one.IsApproximately(one + float.Epsilon), Is.True);
 
-            Assert.That(one.IsApproximately(one - (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
-            Assert.That(one.IsApproximately(one + (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+            Assert.That(one.IsApproximately(one - (float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+            Assert.That(one.IsApproximately(one + (float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
 
             Assert.That(0f.IsApproximately(0f), Is.True);
 
@@ -100,8 +100,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one - new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
             Assert.That(one.IsApproximately(one + new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
 
-            Assert.That(one.IsApproximately(one - new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
-            Assert.That(one.IsApproximately(one + new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+            Assert.That(one.IsApproximately(one - new float2(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+            Assert.That(one.IsApproximately(one + new float2(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
 
             Assert.That(float2.zero.IsApproximately(float2.zero), Is.EqualTo(new bool2(true)));
 
@@ -132,8 +132,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one - new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
             Assert.That(one.IsApproximately(one + new float3(float.Epsilon)), Is.EqualTo(new bool3(true)));
 
-            Assert.That(one.IsApproximately(one - new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
-            Assert.That(one.IsApproximately(one + new float3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+            Assert.That(one.IsApproximately(one - new float3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
+            Assert.That(one.IsApproximately(one + new float3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3(false)));
 
             Assert.That(float3.zero.IsApproximately(float3.zero), Is.EqualTo(new bool3(true)));
 
@@ -160,8 +160,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one - new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
             Assert.That(one.IsApproximately(one + new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
 
-            Assert.That(one.IsApproximately(one - new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
-            Assert.That(one.IsApproximately(one + new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+            Assert.That(one.IsApproximately(one - new float4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+            Assert.That(one.IsApproximately(one + new float4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
 
             Assert.That(float4.zero.IsApproximately(float4.zero), Is.EqualTo(new bool4(true)));
 
@@ -180,8 +180,7 @@ namespace Anvil.Unity.Tests
             float3x3 infinity_negativeInfinity_NaN_row = new float3x3(
                 new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
                 new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
-                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)
-                );
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN));
 
             Assert.That(one.IsApproximately(one), Is.EqualTo(new bool3x3(true)));
             Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool3x3(true)));
@@ -191,8 +190,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one - new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
             Assert.That(one.IsApproximately(one + new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
 
-            Assert.That(one.IsApproximately(one - new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
-            Assert.That(one.IsApproximately(one + new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+            Assert.That(one.IsApproximately(one - new float3x3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+            Assert.That(one.IsApproximately(one + new float3x3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
 
             Assert.That(float3x3.zero.IsApproximately(float3x3.zero), Is.EqualTo(new bool3x3(true)));
 
@@ -215,8 +214,7 @@ namespace Anvil.Unity.Tests
                 new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
                 new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
                 new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN),
-                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN)
-            );
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, float.NaN));
 
             Assert.That(one.IsApproximately(one), Is.EqualTo(new bool4x4(true)));
             Assert.That((-one).IsApproximately(-one), Is.EqualTo(new bool4x4(true)));
@@ -226,8 +224,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximately(one - new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
             Assert.That(one.IsApproximately(one + new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
 
-            Assert.That(one.IsApproximately(one - new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
-            Assert.That(one.IsApproximately(one + new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+            Assert.That(one.IsApproximately(one - new float4x4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+            Assert.That(one.IsApproximately(one + new float4x4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
 
             Assert.That(float4x4.zero.IsApproximately(float4x4.zero), Is.EqualTo(new bool4x4(true)));
 
@@ -256,8 +254,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one - float.Epsilon), Is.True);
             Assert.That(one.IsApproximatelySafe(one + float.Epsilon), Is.True);
 
-            Assert.That(one.IsApproximatelySafe(one - (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
-            Assert.That(one.IsApproximatelySafe(one + (float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+            Assert.That(one.IsApproximatelySafe(one - (float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
+            Assert.That(one.IsApproximatelySafe(one + (float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.False);
 
             Assert.That(0f.IsApproximatelySafe(0f), Is.True);
 
@@ -289,8 +287,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one - new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
             Assert.That(one.IsApproximatelySafe(one + new float2(float.Epsilon)), Is.EqualTo(new bool2(true)));
 
-            Assert.That(one.IsApproximatelySafe(one - new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
-            Assert.That(one.IsApproximatelySafe(one + new float2(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+            Assert.That(one.IsApproximatelySafe(one - new float2(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float2(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool2(false)));
 
             Assert.That(float2.zero.IsApproximatelySafe(float2.zero), Is.EqualTo(new bool2(true)));
 
@@ -349,8 +347,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one - new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
             Assert.That(one.IsApproximatelySafe(one + new float4(float.Epsilon)), Is.EqualTo(new bool4(true)));
 
-            Assert.That(one.IsApproximatelySafe(one - new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
-            Assert.That(one.IsApproximatelySafe(one + new float4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+            Assert.That(one.IsApproximatelySafe(one - new float4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4(false)));
 
             Assert.That(float4.zero.IsApproximatelySafe(float4.zero), Is.EqualTo(new bool4(true)));
 
@@ -369,8 +367,7 @@ namespace Anvil.Unity.Tests
             float3x3 infinity_negativeInfinity_NaN_row = new float3x3(
                 new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
                 new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN),
-                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN)
-                );
+                new float3(float.PositiveInfinity, float.NegativeInfinity, float.NaN));
 
             Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool3x3(true)));
             Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool3x3(true)));
@@ -380,8 +377,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one - new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
             Assert.That(one.IsApproximatelySafe(one + new float3x3(float.Epsilon)), Is.EqualTo(new bool3x3(true)));
 
-            Assert.That(one.IsApproximatelySafe(one - new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
-            Assert.That(one.IsApproximatelySafe(one + new float3x3(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+            Assert.That(one.IsApproximatelySafe(one - new float3x3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float3x3(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool3x3(false)));
 
             Assert.That(float3x3.zero.IsApproximatelySafe(float3x3.zero), Is.EqualTo(new bool3x3(true)));
 
@@ -404,8 +401,7 @@ namespace Anvil.Unity.Tests
                 new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f),
                 new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f),
                 new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f),
-                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f)
-            );
+                new float4(float.PositiveInfinity, float.NegativeInfinity, float.NaN, 3f));
 
             Assert.That(one.IsApproximatelySafe(one), Is.EqualTo(new bool4x4(true)));
             Assert.That((-one).IsApproximatelySafe(-one), Is.EqualTo(new bool4x4(true)));
@@ -415,8 +411,8 @@ namespace Anvil.Unity.Tests
             Assert.That(one.IsApproximatelySafe(one - new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
             Assert.That(one.IsApproximatelySafe(one + new float4x4(float.Epsilon)), Is.EqualTo(new bool4x4(true)));
 
-            Assert.That(one.IsApproximatelySafe(one - new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
-            Assert.That(one.IsApproximatelySafe(one + new float4x4(float.Epsilon+MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+            Assert.That(one.IsApproximatelySafe(one - new float4x4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
+            Assert.That(one.IsApproximatelySafe(one + new float4x4(float.Epsilon + MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE)), Is.EqualTo(new bool4x4(false)));
 
             Assert.That(float4x4.zero.IsApproximatelySafe(float4x4.zero), Is.EqualTo(new bool4x4(true)));
 

--- a/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/MathExtensionTests.cs
@@ -2,6 +2,7 @@ using Anvil.CSharp.Mathematics;
 using Anvil.Unity.Core;
 using NUnit.Framework;
 using Unity.Mathematics;
+using UnityEngine;
 
 namespace Anvil.Unity.Tests
 {
@@ -668,6 +669,26 @@ namespace Anvil.Unity.Tests
             Assert.That(nan_negativeOne_zero_columns.IsEqualOrNaN(zero), Is.EqualTo(new bool4x4(false, false, true, true)));
         }
 
+        // ----- ToRGBAFloat ----- //
+        [Test]
+        public static void ToRGBAFloatTest()
+        {
+            Assert.That(nameof(ToRGBAFloatTest), Does.StartWith(nameof(MathExtension.ToRGBAFloat)));
+
+            Assert.That(new Color(0.1f, 0.2f, 0.3f, 0.4f).ToRGBAFloat(), Is.EqualTo(new float4(0.1f, 0.2f, 0.3f, 0.4f)));
+        }
+
+        // ----- ToRGBFloat ----- //
+        [Test]
+        public static void ToRGBFloatTest()
+        {
+            Assert.That(nameof(ToRGBFloatTest), Does.StartWith(nameof(MathExtension.ToRGBFloat)));
+
+            Assert.That(new Color(0.1f, 0.2f, 0.3f, 0.4f).ToRGBFloat(), Is.EqualTo(new float3(0.1f, 0.2f, 0.3f)));
+            Assert.That(new Color(0.1f, 0.2f, 0.3f).ToRGBFloat(), Is.EqualTo(new float3(0.1f, 0.2f, 0.3f)));
+        }
+
+        // ----- ToString ----- //
         [Test]
         public static void ToStringTest_float2()
         {

--- a/Scripts/Runtime/Core/Util/MathExtension.cs
+++ b/Scripts/Runtime/Core/Util/MathExtension.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using Anvil.CSharp.Mathematics;
 using Unity.Mathematics;
+using UnityEngine;
 
 namespace Anvil.Unity.Core
 {
@@ -398,6 +399,26 @@ namespace Anvil.Unity.Core
                     math.isnan(a.c1) & math.isnan(b.c1),
                     math.isnan(a.c2) & math.isnan(b.c2),
                     math.isnan(a.c3) & math.isnan(b.c3));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="float4"/> representation of a <see cref="Color"/> where the rgba components map to xyzw
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The float representation.</returns>
+        public static float4 ToRGBAFloat(this in Color color)
+        {
+            return new float4(color.r, color.g, color.b, color.a);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="float3"/> representation of a <see cref="Color"/> where the rgb components map to xyz
+        /// </summary>
+        /// <param name="color">The color to convert.</param>
+        /// <returns>The float representation.</returns>
+        public static float3 ToRGBFloat(this in Color color)
+        {
+            return new float3(color.r, color.g, color.b);
         }
 
         /// <summary>


### PR DESCRIPTION
Add convenience `MathExtension` methods to transform a `Color` to a `float3` or `float4`

### What is the current behaviour?

There are no conversion methods. Developers must manually map rgb(a) to xyz(w) if they are using the newer `Unity.Mathematics` types.

### What is the new behaviour?

Developers can call `myColor.ToRGBA()` or `myColor.ToRGB()` to convert their `Color` instance into a `float4` or `float3` representation.

### What issues does this resolve?

None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
