### PR TITLE
DeferAutoRefreshUntilPlayPressed - Add

### DIFF
--- a/Scripts/Editor/AssetImport/DeferAutoRefreshUntilPlayPressed.cs.meta
+++ b/Scripts/Editor/AssetImport/DeferAutoRefreshUntilPlayPressed.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 33b3eee9fb3e4387bfee2bea511ec577
+timeCreated: 1683319986


### PR DESCRIPTION
Defers the editor from importing/compiling assets until the developer presses play.

This allows developers to
 - Save code as they develop without bogging down their machine
 - Conduct big asset renames/refactors without triggering re-import
 - Start playing their game in the editor with a single interaction.
    - No more regain focus -> wait for compile -> press play -> wait for startup.

## Tag Along
 - `PreventAutoRefreshWhilePlaying` - `IsEnabled` and `IsAutoRefreshDisabled` are now publicly readable.
    - This allows the two prevent scripts to coordinate forced asset refreshes if both enabled (why?)

### What is the current behaviour?

The Unity Editor automatically refreshes assets as it detects changes on the file system. This:
 - Can cause the developer to routinely wait for unrelated changes to compile
 - Requires the developer to interact multiple times with the editor spaced over the duration of compiles each time they want to start the game (after changes).

### What is the new behaviour?

When enabled, the editor doesn't refresh the asset database until the play button is pressed. Once the play button is pressed.
 - Assets are refreshed (import and compile)
 - The game starts playing

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
