### PR TITLE
Adding an Editor Input Dialog

### DIFF
--- a/Scripts/Editor/UI.meta
+++ b/Scripts/Editor/UI.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4455be8d062341728051af0447ed4467
+timeCreated: 1684421683

--- a/Scripts/Editor/UI/EditorInputDialog.cs
+++ b/Scripts/Editor/UI/EditorInputDialog.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -21,11 +20,9 @@ namespace Anvil.Unity.Editor.UI
         /// <param name="cancelBtnText">What the "Cancel" button should read</param>
         /// <param name="defaultInputText">The default text in the input box if needed</param>
         /// <returns>
-        /// The input text the user entered.
-        /// If the user pressed the "OK" button, this will be whatever they have entered.
-        /// If the user pressed the "Cancel" button, this will be string.Empty.
+        /// The <see cref="EditorInputDialogResult"/>
         /// </returns>
-        public static string Show(
+        public static EditorInputDialogResult Show(
             string title,
             string description,
             string inputTextLabel,
@@ -34,8 +31,6 @@ namespace Anvil.Unity.Editor.UI
             string defaultInputText = null)
         {
             Vector2 maxPos = GUIUtility.GUIToScreenPoint(new Vector2(Screen.width, Screen.height));
-
-            string result = string.Empty;
 
             EditorInputDialog window = CreateInstance<EditorInputDialog>();
             window.Init(
@@ -46,14 +41,10 @@ namespace Anvil.Unity.Editor.UI
                 okBtnText,
                 cancelBtnText,
                 defaultInputText);
-            window.OnComplete += (resultString) => result = resultString;
             window.ShowModal();
 
-            return result;
+            return window.Result;
         }
-
-
-        private event Action<string> OnComplete;
 
         private string m_Description;
         private string m_InputTextLabel;
@@ -63,6 +54,8 @@ namespace Anvil.Unity.Editor.UI
 
         private bool m_HasInitializedPosition;
         private string m_InputText;
+
+        public EditorInputDialogResult Result { get; private set; }
 
         private void Init(
             Vector2 maxPos,
@@ -102,13 +95,13 @@ namespace Anvil.Unity.Editor.UI
             controlRect.width *= 0.5f;
             if (GUI.Button(controlRect, m_OKBtnText))
             {
-                Complete(false);
+                Complete(EditorInputDialogResult.ResultAction.Ok);
             }
 
             controlRect.x += controlRect.width;
             if (GUI.Button(controlRect, m_CancelBtnText))
             {
-                Complete(true);
+                Complete(EditorInputDialogResult.ResultAction.Cancel);
             }
 
             EditorGUILayout.Space(8);
@@ -128,19 +121,20 @@ namespace Anvil.Unity.Editor.UI
             {
                 return;
             }
-            
+
+
             // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
             switch (currentEvent.keyCode)
             {
                 case KeyCode.Escape:
                     currentEvent.Use();
-                    Complete(true);
+                    Complete(EditorInputDialogResult.ResultAction.Cancel);
                     break;
 
                 case KeyCode.Return:
                 case KeyCode.KeypadEnter:
                     currentEvent.Use();
-                    Complete(false);
+                    Complete(EditorInputDialogResult.ResultAction.Ok);
                     break;
             }
         }
@@ -169,10 +163,9 @@ namespace Anvil.Unity.Editor.UI
             Focus();
         }
 
-        private void Complete(bool isCancel)
+        private void Complete(EditorInputDialogResult.ResultAction resultAction)
         {
-            OnComplete?.Invoke(isCancel ? string.Empty : m_InputText);
-            Close();
+            Result = new EditorInputDialogResult(resultAction, m_InputText);
         }
     }
 }

--- a/Scripts/Editor/UI/EditorInputDialog.cs
+++ b/Scripts/Editor/UI/EditorInputDialog.cs
@@ -1,0 +1,178 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anvil.Unity.Editor.UI
+{
+    /// <summary>
+    /// Helper class to show an Input dialog in the editor.
+    /// </summary>
+    public class EditorInputDialog : EditorWindow
+    {
+        private const string CONTROL_NAME_INPUT_TEXT = "EditorInputDialog_INPUT_TEXT";
+
+        /// <summary>
+        /// Shows the Input Dialog
+        /// </summary>
+        /// <param name="title">The title of the Dialog window</param>
+        /// <param name="description">The description text to communicate what the user should do</param>
+        /// <param name="inputTextLabel">A label to describe the input text</param>
+        /// <param name="okBtnText">What the "OK" button should read</param>
+        /// <param name="cancelBtnText">What the "Cancel" button should read</param>
+        /// <param name="defaultInputText">The default text in the input box if needed</param>
+        /// <returns>
+        /// The input text the user entered.
+        /// If the user pressed the "OK" button, this will be whatever they have entered.
+        /// If the user pressed the "Cancel" button, this will be string.Empty.
+        /// </returns>
+        public static string Show(
+            string title,
+            string description,
+            string inputTextLabel,
+            string okBtnText,
+            string cancelBtnText,
+            string defaultInputText = null)
+        {
+            Vector2 maxPos = GUIUtility.GUIToScreenPoint(new Vector2(Screen.width, Screen.height));
+
+            string result = string.Empty;
+
+            EditorInputDialog window = CreateInstance<EditorInputDialog>();
+            window.Init(
+                maxPos,
+                title,
+                description,
+                inputTextLabel,
+                okBtnText,
+                cancelBtnText,
+                defaultInputText);
+            window.OnComplete += (resultString) => result = resultString;
+            window.ShowModal();
+
+            return result;
+        }
+
+
+        private event Action<string> OnComplete;
+
+        private string m_Description;
+        private string m_InputTextLabel;
+        private string m_OKBtnText;
+        private string m_CancelBtnText;
+        private Vector2 m_MaxScreenPosition;
+
+        private bool m_HasInitializedPosition;
+        private string m_InputText;
+
+        private void Init(
+            Vector2 maxPos,
+            string titleText,
+            string description,
+            string inputTextLabel,
+            string okBtnText,
+            string cancelBtnText,
+            string defaultInputText = null)
+        {
+            m_MaxScreenPosition = maxPos;
+            titleContent = new GUIContent(titleText);
+            m_Description = description;
+            m_InputTextLabel = inputTextLabel;
+            m_OKBtnText = okBtnText;
+            m_CancelBtnText = cancelBtnText;
+            m_InputText = defaultInputText ?? string.Empty;
+        }
+
+        private void OnGUI()
+        {
+            Event currentEvent = Event.current;
+            CheckKeyboard(currentEvent);
+
+            Rect rect = EditorGUILayout.BeginVertical();
+
+            EditorGUILayout.Space(12);
+            EditorGUILayout.LabelField(m_Description);
+
+            EditorGUILayout.Space(8);
+            GUI.SetNextControlName(CONTROL_NAME_INPUT_TEXT);
+            m_InputText = EditorGUILayout.TextField(m_InputTextLabel, m_InputText);
+            GUI.FocusControl(CONTROL_NAME_INPUT_TEXT);
+            EditorGUILayout.Space(12);
+
+            Rect controlRect = EditorGUILayout.GetControlRect();
+            controlRect.width *= 0.5f;
+            if (GUI.Button(controlRect, m_OKBtnText))
+            {
+                Complete(false);
+            }
+
+            controlRect.x += controlRect.width;
+            if (GUI.Button(controlRect, m_CancelBtnText))
+            {
+                Complete(true);
+            }
+
+            EditorGUILayout.Space(8);
+            EditorGUILayout.EndVertical();
+
+            if (rect.width != 0 && minSize != rect.size)
+            {
+                minSize = maxSize = rect.size;
+            }
+
+            InitializePosition(currentEvent);
+        }
+
+        private void CheckKeyboard(Event currentEvent)
+        {
+            if (currentEvent.type != EventType.KeyDown)
+            {
+                return;
+            }
+            
+            // ReSharper disable once SwitchStatementMissingSomeEnumCasesNoDefault
+            switch (currentEvent.keyCode)
+            {
+                case KeyCode.Escape:
+                    currentEvent.Use();
+                    Complete(true);
+                    break;
+
+                case KeyCode.Return:
+                case KeyCode.KeypadEnter:
+                    currentEvent.Use();
+                    Complete(false);
+                    break;
+            }
+        }
+
+        private void InitializePosition(Event currentEvent)
+        {
+            if (m_HasInitializedPosition || currentEvent.type != EventType.Layout)
+            {
+                return;
+            }
+            m_HasInitializedPosition = true;
+
+            Vector2 mousePos = GUIUtility.GUIToScreenPoint(currentEvent.mousePosition);
+            mousePos.x += 32;
+            if (mousePos.x + position.width > m_MaxScreenPosition.x)
+            {
+                mousePos.x -= position.width + 64;
+            }
+            if (mousePos.y + position.height > m_MaxScreenPosition.y)
+            {
+                mousePos.y = m_MaxScreenPosition.y - position.height;
+            }
+
+            position = new Rect(mousePos.x, mousePos.y, position.width, position.height);
+
+            Focus();
+        }
+
+        private void Complete(bool isCancel)
+        {
+            OnComplete?.Invoke(isCancel ? string.Empty : m_InputText);
+            Close();
+        }
+    }
+}

--- a/Scripts/Editor/UI/EditorInputDialog.cs.meta
+++ b/Scripts/Editor/UI/EditorInputDialog.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5fbd153e88ac496b893d049d193c22e8
+timeCreated: 1684245884

--- a/Scripts/Editor/UI/EditorInputDialogResult.cs
+++ b/Scripts/Editor/UI/EditorInputDialogResult.cs
@@ -1,0 +1,35 @@
+namespace Anvil.Unity.Editor.UI
+{
+    /// <summary>
+    /// The result of a <see cref="EditorInputDialog"/> being shown.
+    /// </summary>
+    public class EditorInputDialogResult
+    {
+        /// <summary>
+        /// Represents the action the user took with the dialog
+        /// </summary>
+        public enum ResultAction
+        {
+            //Ok or the affirmative action
+            Ok,
+            //Cancel or the negative action
+            Cancel
+        }
+
+        /// <summary>
+        /// The <see cref="ResultAction"/> the user took with the dialog
+        /// </summary>
+        public readonly ResultAction Result;
+        /// <summary>
+        /// The text entered into the input box.
+        /// NOTE: This will be string.Empty if the user took the <see cref="ResultAction.Cancel"/> route.
+        /// </summary>
+        public readonly string ResultText;
+        
+        internal EditorInputDialogResult(ResultAction result, string resultText)
+        {
+            Result = result;
+            ResultText = Result == ResultAction.Ok ? resultText : string.Empty;
+        }
+    }
+}

--- a/Scripts/Editor/UI/EditorInputDialogResult.cs.meta
+++ b/Scripts/Editor/UI/EditorInputDialogResult.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b72883f721ae41bf9ddd2aaacbb00ef7
+timeCreated: 1684505544


### PR DESCRIPTION
Unity has a built in Dialog to give you information and buttons but nothing to let the user enter in their own text. 

### What is the current behaviour?

This doesn't exist today.

### What is the new behaviour?

We now have a dialog that can take in user input. 

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
