### PR TITLE
DeferAutoRefreshUntilPlayPressed - Fix state not setting on initial load

### DIFF
--- a/Scripts/Editor/AssetImport/DeferAutoRefreshUntilPlayPressed.cs
+++ b/Scripts/Editor/AssetImport/DeferAutoRefreshUntilPlayPressed.cs
@@ -31,6 +31,7 @@ namespace Anvil.Unity.Editor.AssetImport
         static DeferAutoRefreshUntilPlayPressed()
         {
             EditorApplication.playModeStateChanged += EditorApplication_PlayModeStateChanged;
+            UpdateAutoRefreshAtRest();
         }
 
         [MenuItem(MENU_PATH)]
@@ -48,15 +49,7 @@ namespace Anvil.Unity.Editor.AssetImport
                     "Thanks Boss");
             }
 
-            bool shouldPreventRefresh = IsEnabled;
-            if (shouldPreventRefresh)
-            {
-                PreventAutoRefresh();
-            }
-            else
-            {
-                AllowAutoRefresh();
-            }
+            UpdateAutoRefreshAtRest();
         }
 
         [MenuItem(MENU_PATH, true)]
@@ -100,6 +93,23 @@ namespace Anvil.Unity.Editor.AssetImport
                 case PlayModeStateChange.EnteredEditMode:
                     PreventAutoRefresh();
                     break;
+            }
+        }
+
+        /// <summary>
+        /// Set the auto refresh state when the editor state hasn't changed.
+        /// Ensures that we're blocking or allowing auto refresh based on the <see cref="IsEnabled"/> state.
+        /// </summary>
+        private static void UpdateAutoRefreshAtRest()
+        {
+            bool shouldPreventRefresh = IsEnabled;
+            if (shouldPreventRefresh)
+            {
+                PreventAutoRefresh();
+            }
+            else
+            {
+                AllowAutoRefresh();
             }
         }
 


### PR DESCRIPTION
Fix a bug with `DeferAutoRefreshUntilPlayPressed` where the functionality would not be enabled on the initial load of the editor.

### What is the current behaviour?

Until the first play session in the Unity Editor (or the option explicitly changed) the enabled state of `DeferAutoRefreshUntilPlayPressed` would not be correctly applied. Asset refresh/compile would not be deferred.

### What is the new behaviour?

`DeferAutoRefreshUntilPlayPressed` works correctly on initial editor load if enabled.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
