### PR TITLE
Adding Console Helper for finding first Error in the log

### DIFF
--- a/Scripts/Editor/AssemblyInjections.meta
+++ b/Scripts/Editor/AssemblyInjections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48501675aae634224b5c18416a9dd5f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/AssemblyInjections/UnityEditor.meta
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53f4ec085785649bfa2225b152dec68f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Anvil.Unity.Editor.Debug
+{
+    public static class ConsoleHelper
+    {
+        //Had to figure this out from old Unity decompiled code. Not sure where this is defined today sadly.
+        //But it's unlikely to ever change as so much would have to be changed in the Unity Editor to accomodate.
+        private const int ERROR_FLAG = 512;
+        
+        [MenuItem("Anvil/Debug/Skip to First Error")]
+        internal static void SkipToFirstError()
+        {
+            //If we're not showing errors in the console window, we can't really scroll to it can we?
+            if ((LogEntries.consoleFlags & ERROR_FLAG) == 0)
+            {
+                //Let the user decide...
+                if (EditorUtility.DisplayDialog(
+                    "Incorrect Configuration",
+                    "Errors are not being show in the Console currently. Do you want them to be enabled and try again?",
+                    "Enable",
+                    "Cancel"))
+                {
+                    LogEntries.SetConsoleFlag(ERROR_FLAG, true);
+                }
+                else
+                {
+                    return;
+                }
+            }
+            
+            int errorCount = 0;
+            int warningCount = 0;
+            int defaultCount = 0;
+            LogEntries.GetCountsByType(ref errorCount, ref warningCount, ref defaultCount);
+
+            //No point doing any work if there aren't any errors to scroll to.
+            if (errorCount == 0)
+            {
+                return;
+            }
+
+            Type consoleWindowType = typeof(ConsoleWindow);
+            ConsoleWindow consoleWindowInstance = (ConsoleWindow)consoleWindowType.GetField("ms_ConsoleWindow", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+            ListViewState listViewState = (ListViewState)consoleWindowType.GetField("m_ListView", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(consoleWindowInstance);
+
+            int numLogEntries = LogEntries.GetCount();
+            LogEntry outputLogEntry = new LogEntry();
+
+            LogEntries.StartGettingEntries();
+            for (int i = 0; i < numLogEntries; ++i)
+            {
+                LogEntries.GetEntryInternal(i, outputLogEntry);
+
+                if (!IsError(outputLogEntry.mode))
+                {
+                    continue;
+                }
+
+                Vector2 scrollPos = listViewState.scrollPos;
+                scrollPos.y = i * listViewState.rowHeight;
+                listViewState.scrollPos = scrollPos;
+                ConsoleWindow.ShowConsoleRow(i);
+                break;
+            }
+            LogEntries.EndGettingEntries();
+        }
+
+        private static bool IsError(int mode)
+        {
+            return (mode
+                    & ((int)ConsoleWindow.Mode.Fatal
+                        | (int)ConsoleWindow.Mode.Assert
+                        | (int)ConsoleWindow.Mode.Error
+                        | (int)ConsoleWindow.Mode.ScriptCompileError
+                        | (int)ConsoleWindow.Mode.ScriptingError
+                        | (int)ConsoleWindow.Mode.AssetImportError
+                        | (int)ConsoleWindow.Mode.ScriptingAssertion
+                        | (int)ConsoleWindow.Mode.ScriptingException
+                        | (int)ConsoleWindow.Mode.ReportBug
+                        | (int)ConsoleWindow.Mode.StickyError))
+                != 0;
+        }
+    }
+}

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs
@@ -7,6 +7,12 @@ namespace Anvil.Unity.Editor.Debug
 {
     public static class ConsoleHelper
     {
+        // TODO: Future
+        // Should one wish to extend this functionality, adding this as a custom button overlaid on the Console Window
+        // is probably helpful and better than a tools menu.
+        // Additional features would be the ability to keep track of which error we are on and be able to go next/back
+        // as well as first and last. 
+        
         //Had to figure this out from old Unity decompiled code. Not sure where this is defined today sadly.
         //But it's unlikely to ever change as so much would have to be changed in the Unity Editor to accomodate.
         private const int ERROR_FLAG = 512;

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs
@@ -3,11 +3,11 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
-namespace Anvil.Unity.Editor.Debug
+namespace Anvil.Unity.Editor.Debugging
 {
     public static class ConsoleHelper
     {
-        // TODO: Future
+        // TODO: #117
         // Should one wish to extend this functionality, adding this as a custom button overlaid on the Console Window
         // is probably helpful and better than a tools menu.
         // Additional features would be the ability to keep track of which error we are on and be able to go next/back

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs.meta
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/ConsoleHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c196b5b87a38420599ffd1735726f1d2
+timeCreated: 1695998644

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/Unity.InternalAPIEditorBridge.001.asmdef
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/Unity.InternalAPIEditorBridge.001.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Unity.InternalAPIEngineBridge.001",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/Unity.InternalAPIEditorBridge.001.asmdef
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/Unity.InternalAPIEditorBridge.001.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Unity.InternalAPIEngineBridge.001",
+    "name": "Unity.InternalAPIEditorBridge.001",
     "rootNamespace": "",
     "references": [],
     "includePlatforms": [

--- a/Scripts/Editor/AssemblyInjections/UnityEditor/Unity.InternalAPIEditorBridge.001.asmdef.meta
+++ b/Scripts/Editor/AssemblyInjections/UnityEditor/Unity.InternalAPIEditorBridge.001.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64bbb7e947ecf44958b4a06af7d1ada2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Simple helper utility to get the first error in the Console Window.

### What is the current behaviour?

Often when developing there will be a ton of logs emitted in the Console Window. Eventually there might be an error. 

To find the first error, you can easily turn off regular logs and warnings so you only have Errors to see it. 

That might be fine but usually reading the regular/warning logs beforehand are helpful to understand the context of the Error. 

There is no way to do this and you may have to scroll manually to try and find the error which can be challenging and annoying.

### What is the new behaviour?

A simple Tools menu item under `Anvil / Debug / Skip to First Error` exists. 

This will scroll to the first error and select it for you. You can then easily scroll up manually to be able to see the context above. 

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No

### Additional Information

This also exposes a neat feature that we can hijack from how Unity's own Packages `Unity.Rendering`, `Unity.InputSystem` etc are able to access the internals in `UnityEngine.dll` and `UnityEditor.dll`

Unity has exposed special paths for Assembly Definitions called "InternalBridges" as friends of the `UnityEngine.dll` and `UnityEditor.dll` assemblies. 

Since we are unable to create an Assembly Reference for those built in dlls, we can't use the normal method of Assembly Injection. 

Instead we put our code into one of the bridges and we get access that way.

**Engine** - `Unity.InternalAPIEngineBridge.001`
**Editor** - `Unity.InternalAPIEditorBridge.001`
