### PR TITLE
EditorInputDialog - Close on Complete

### DIFF
--- a/Scripts/Editor/UI/EditorInputDialog.cs
+++ b/Scripts/Editor/UI/EditorInputDialog.cs
@@ -166,6 +166,7 @@ namespace Anvil.Unity.Editor.UI
         private void Complete(EditorInputDialogResult.ResultAction resultAction)
         {
             Result = new EditorInputDialogResult(resultAction, m_InputText);
+            Close();
         }
     }
 }


### PR DESCRIPTION
When the dialog was completed it would not automatically close leading users to believe that the data had not been accepted.

### What is the current behaviour?
The `EditorInputDialog` does not close when it is completed (button press, enter, escape, etc..)

### What is the new behaviour?
`EditorInputDialog` calls `this.Close()` as part of the `Complete()` call.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - If you were compensating for this deficiency by manually closing yourself then remove that call.
 - [ ] No
