### PR TITLE
Fixing error when using Android Platform

### DIFF
--- a/Scripts/Runtime/Core/Util/ScreenUtil.cs
+++ b/Scripts/Runtime/Core/Util/ScreenUtil.cs
@@ -112,7 +112,7 @@ namespace Anvil.Unity.Core
 #if UNITY_ANDROID
             // According to docs the DPI value returned isn't reliable on Android. The docs have a link to a forum post
             // with a native implementation that works.
-            throw new NotSupportedException("NormalizeToScreenEdgeProcessor is not supported on Android. GetDPI needs to be implemented and tested. See: https://docs.unity3d.com/ScriptReference/Screen-dpi.html");
+            throw new System.NotSupportedException("NormalizeToScreenEdgeProcessor is not supported on Android. GetDPI needs to be implemented and tested. See: https://docs.unity3d.com/ScriptReference/Screen-dpi.html");
 #endif
 
             float dpi = Screen.dpi;


### PR DESCRIPTION
There is an import error when on the Android Platform in `ScreenUtil`

### What is the current behaviour?

Throws a compiler error due to not having the right import

### What is the new behaviour?

Fully qualifying the class in the ifdefs so it doesn't error but also doesn't get erased if we are not on the Android Platform and do an organize imports.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
