### PR TITLE
DeferAutoRefreshUntilPlayPressed - Improve Logging

### DIFF
--- a/Scripts/Editor/AssetImport/DeferAutoRefreshUntilPlayPressed.cs
+++ b/Scripts/Editor/AssetImport/DeferAutoRefreshUntilPlayPressed.cs
@@ -119,6 +119,7 @@ namespace Anvil.Unity.Editor.AssetImport
             {
                 IsAutoRefreshDisabled = true;
                 AssetDatabase.DisallowAutoRefresh();
+                s_Logger.Debug("Auto asset refresh disabled.");
             }
         }
 
@@ -128,6 +129,7 @@ namespace Anvil.Unity.Editor.AssetImport
             {
                 AssetDatabase.AllowAutoRefresh();
                 IsAutoRefreshDisabled = false;
+                s_Logger.Debug("Auto asset refresh enabled.");
 
                 // Only refresh if the other prevention script isn't blocking refresh.
                 if (!PreventAutoRefreshWhilePlaying.IsAutoRefreshDisabled)


### PR DESCRIPTION
### What is the current behaviour?

`DeferAutoRefreshUntilPlayPressed` does not emit any logs when preventing or allowing auto refresh.

### What is the new behaviour?

Log AssetDatabase refresh changes.
This matches the behaviour of the `PreventAutoRefreshWhilePlaying` script

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
