### PR TITLE
Logging - Fix error on `PendingLogPump` destroy

### DIFF
--- a/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
+++ b/Scripts/Runtime/Logging/.CSProject/UnityLogListener.cs
@@ -102,7 +102,10 @@ namespace Anvil.Unity.Logging
 
             private void OnDestroy()
             {
-                StopCoroutine(m_EndOfFrameRoutine);
+                if (m_EndOfFrameRoutine != null)
+                {
+                    StopCoroutine(m_EndOfFrameRoutine);
+                }
 
                 // This is our last chance to process
                 OnProcessPendingLogs?.Invoke();

--- a/Scripts/Runtime/Logging/anvil-unity-logging.dll
+++ b/Scripts/Runtime/Logging/anvil-unity-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b8b2144b263d40626d268b71b63106860b3e4d2506c77b485b46a3d9dcfa758
+oid sha256:9fd506a8f72cb4b3ff49c9c17d224c1f9804622fbb605b674f6a830c2b104f29
 size 15360


### PR DESCRIPTION
Fix exception thrown on `PendingLogPump` destroy when destroyed before `Start()` is called.

### What is the current behaviour?

If `PendingLogPump` is destroyed before `Start()` has been called it will throw an error because the routine hasn't been set up yet.

### What is the new behaviour?

We now perform a null check before trying to stop the routine.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
