### PR TITLE
Added `ScaleAroundPoint` and `RotateAroundPoint` transform extensions

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
@@ -1,9 +1,11 @@
 using Anvil.Unity.Core;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools.Utils;
 
 namespace Anvil.Unity.Tests
 {
+    [TestFixture]
     public class TransformExtensionTests
     {
         [Test]
@@ -36,6 +38,59 @@ namespace Anvil.Unity.Tests
             // Teardown
             GameObject.DestroyImmediate(parentGO);
             GameObject.DestroyImmediate(childGO);
+        }
+        
+        [Test]
+        public static void ScaleAroundPointTest()
+        {
+            Assert.That(nameof(ScaleAroundPointTest), Is.EqualTo(nameof(TransformExtension.ScaleAroundPoint) + "Test"));
+            
+            Transform transform = new GameObject().transform;
+            
+            transform.localPosition = new Vector3(1f, 2f, 3f);
+            transform.localScale = Vector3.one;
+            transform.ScaleAroundPoint(2f, Vector3.zero);
+            Assert.That(transform.localScale, Is.EqualTo(new Vector3(2f, 2f, 2f)));
+            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(2f, 4f, 6f)));
+
+            transform.localPosition = new Vector3(1f, 2f, 3f);
+            transform.localScale = Vector3.one;
+            transform.ScaleAroundPoint(new Vector3(2f, 3f, 4f), Vector3.zero);
+            Assert.That(transform.localScale, Is.EqualTo(new Vector3(2f, 3f, 4f)));
+            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(2f, 6f, 12f)));
+
+            transform.localPosition = new Vector3(1f, 2f, 3f);
+            transform.localScale = Vector3.one;
+            transform.ScaleAroundPoint(2f, new Vector3(5f, 5f, 5f));
+            Assert.That(transform.localScale, Is.EqualTo(new Vector3(2f, 2f, 2f)));
+            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(-3f, -1f, 1f)));
+
+            transform.localPosition = new Vector3(1f, 2f, 3f);
+            transform.localScale = Vector3.one;
+            transform.ScaleAroundPoint(new Vector3(2f, 3f, 4f), new Vector3(5f, 5f, 5f));
+            Assert.That(transform.localScale, Is.EqualTo(new Vector3(2f, 3f, 4f)));
+            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(-3f, -4f, -3f)));
+        }
+        
+        [Test]
+        public static void RotateAroundPointTest()
+        {
+            Assert.That(nameof(RotateAroundPointTest), Is.EqualTo(nameof(TransformExtension.RotateAroundPoint) + "Test"));
+            
+            Vector3EqualityComparer vector3Comparer = new (10e-7f);
+            Transform transform = new GameObject().transform;
+            
+            transform.localPosition = new Vector3(1f, 2f, 3f);
+            transform.localRotation = Quaternion.identity;
+            transform.RotateAroundPoint(Quaternion.AngleAxis(90f, Vector3.forward), Vector3.zero);
+            Assert.That(transform.localRotation.eulerAngles, Is.EqualTo(new Vector3(0f, 0f, 90f)));
+            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(-2f, 1f, 3f)).Using(vector3Comparer));
+            
+            transform.localPosition = new Vector3(1f, 2f, 3f);
+            transform.localRotation = Quaternion.identity;
+            transform.RotateAroundPoint(Quaternion.AngleAxis(90f, Vector3.forward), new Vector3(5f, 5f, 5f));
+            Assert.That(transform.localRotation.eulerAngles, Is.EqualTo(new Vector3(0f, 0f, 90f)));
+            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(8f, 1f, 3f)).Using(vector3Comparer));
         }
     }
 }

--- a/Scripts/Runtime/Core/Util/TransformExtension.cs
+++ b/Scripts/Runtime/Core/Util/TransformExtension.cs
@@ -21,5 +21,42 @@ namespace Anvil.Unity.Core
                 scale.y / transform.lossyScale.y,
                 scale.z / transform.lossyScale.z);
         }
+        
+        /// <inheritdoc cref="ScaleAroundPoint(UnityEngine.Transform,UnityEngine.Vector3,UnityEngine.Vector3)"/>
+        public static void ScaleAroundPoint(this Transform transform, float scale, Vector3 worldSpacePivot)
+        {
+            transform.ScaleAroundPoint(Vector3.one * scale, worldSpacePivot);
+        }
+        
+        /// <summary>
+        /// Scale the transform around a world-space pivot.
+        /// </summary>
+        /// <param name="transform">The transform to scale.</param>
+        /// <param name="scale">The scale factor applied to the transform.</param>
+        /// <param name="worldSpacePivot">The pivot point on which the scale is centered.</param>
+        public static void ScaleAroundPoint(this Transform transform, Vector3 scale, Vector3 worldSpacePivot)
+        {
+            Vector3 pivotToPos = transform.position - worldSpacePivot;
+            Vector3 localScale = transform.localScale;
+            localScale.Scale(scale);
+            transform.localScale = localScale;
+            transform.localPosition += Vector3.Scale(pivotToPos, scale - Vector3.one);
+        }
+        
+        /// <summary>
+        /// Rotate the transform around a world-space pivot.
+        /// </summary>
+        /// <param name="transform">The transform to rotate.</param>
+        /// <param name="rotation">The rotation applied to the transform.</param>
+        /// <param name="worldSpacePivot">The pivot point around which the rotation is centered.</param>
+        public static void RotateAroundPoint(this Transform transform, Quaternion rotation, Vector3 worldSpacePivot)
+        {
+            Vector3 localSpacePivot = transform.InverseTransformPoint(worldSpacePivot);
+            Vector3 rotatedLocalSpacePivot = rotation * localSpacePivot;
+            Vector3 positionOffset = localSpacePivot - rotatedLocalSpacePivot;
+            
+            transform.localRotation = rotation * transform.localRotation;
+            transform.localPosition += positionOffset;
+        }
     }
 }


### PR DESCRIPTION
### What is the current behaviour?

### What is the new behaviour?
Added `ScaleAroundPoint` and `RotateAroundPoint` transform extensions

### What issues does this resolve?

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
