### PR TITLE
Added Transform extension `Reset`

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
@@ -9,6 +9,25 @@ namespace Anvil.Unity.Tests
     public class TransformExtensionTests
     {
         [Test]
+        public static void ResetTest()
+        {
+            Assert.That(nameof(ResetTest), Is.EqualTo(nameof(TransformExtension.Reset) + "Test"));
+            
+            Transform transform = new GameObject().transform;
+            
+            transform.localPosition = new Vector3(RandomFloat(), RandomFloat(), RandomFloat());
+            transform.localRotation = Quaternion.Euler(new Vector3(RandomFloat(), RandomFloat(), RandomFloat()));
+            transform.localScale = new Vector3(RandomFloat(), RandomFloat(), RandomFloat());
+            transform.Reset();
+            Assert.That(transform.localPosition, Is.EqualTo(Vector3.zero));
+            Assert.That(transform.localRotation, Is.EqualTo(Quaternion.identity));
+            Assert.That(transform.localScale, Is.EqualTo(Vector3.one));
+            return;
+            
+            float RandomFloat() => Random.Range(-float.MaxValue, float.MaxValue);
+        }
+        
+        [Test]
         public static void SetLossyScaleTest()
         {
             Assert.That(nameof(SetLossyScaleTest), Is.EqualTo(nameof(TransformExtension.SetLossyScale) + "Test"));

--- a/Scripts/Runtime/Core/Util/TransformExtension.cs
+++ b/Scripts/Runtime/Core/Util/TransformExtension.cs
@@ -8,6 +8,17 @@ namespace Anvil.Unity.Core
     public static class TransformExtension
     {
         /// <summary>
+        /// Resets the transform's local-space values to default (position zero, rotation zero, scale one).
+        /// </summary>
+        /// <param name="transform">The transform to reset.</param>
+        public static void Reset(this Transform transform)
+        {
+            transform.localPosition = Vector3.zero;
+            transform.localRotation = Quaternion.identity;
+            transform.localScale = Vector3.one;
+        }
+        
+        /// <summary>
         /// Sets the world scale on a transform.
         /// </summary>
         /// <param name="transform">The transform to set the scale on.</param>


### PR DESCRIPTION
Added `TransformExtension.Reset()` to reset a transform's local values to defaults.

### What is the current behaviour?

### What is the new behaviour?

### What issues does this resolve?

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [X] No
