### PR TITLE
Add PhysicsUtil

### DIFF
--- a/Scripts/Runtime/Physics.meta
+++ b/Scripts/Runtime/Physics.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 72fad2898ac24c5a9b80a816db388516
+timeCreated: 1720231943

--- a/Scripts/Runtime/Physics/PhysicsUtil.cs
+++ b/Scripts/Runtime/Physics/PhysicsUtil.cs
@@ -1,0 +1,116 @@
+using System;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Anvil.Unity.Physics
+{
+    /// <summary>
+    /// A collection of utility methods for working with Unity's physics system.
+    /// </summary>
+    public static class PhysicsUtil
+    {
+        /// <summary>
+        /// Extrapolate the provided state for a given <see cref="UnityEngine.Rigidbody"/>.
+        ///
+        /// Note: Does not account for collisions or trigger <see cref="FixedUpdate"/> on the body.
+        ///       For a more accurate extrapolation <see cref="UnityEngine.Physics.Simulate"/> is more appropriate.
+        /// </summary>
+        /// <remarks>
+        /// Only drag and gravity values are read off of the provided <see cref="Rigidbody"/>. All other actor state is
+        /// provided through the method parameters.
+        /// </remarks>
+        public static void ExtrapolateState(
+            float delta,
+            Rigidbody rigidbody,
+            ref Vector3 position,
+            ref Quaternion rotation,
+            ref Vector3 linearVelocity,
+            ref Vector3 angularVelocity)
+        {
+            float drag = rigidbody.drag;
+            float angularDrag = rigidbody.angularDrag;
+            Vector3 gravity = rigidbody.useGravity ? UnityEngine.Physics.gravity : Vector3.zero;
+
+            while (delta > 0f)
+            {
+                float stepDelta = math.min(delta, Time.fixedDeltaTime);
+                StepState(stepDelta,
+                    drag,
+                    angularDrag,
+                    gravity,
+                    ref position,
+                    ref rotation,
+                    ref linearVelocity,
+                    ref angularVelocity);
+                delta -= stepDelta;
+            }
+        }
+
+        /// <summary>
+        /// Extrapolate the provided state for a given <see cref="Rigidbody"/> and execute a callback on each step.
+        ///
+        /// Note: Does not account for collisions or trigger <see cref="FixedUpdate"/> on the body.
+        ///       For a more accurate extrapolation <see cref="Physics.Simulate"/> is more appropriate.
+        /// </summary>
+        /// <param name="onStep">
+        /// Executed after each time the state is stepped. This can be used to apply additional effects each step to
+        /// simulate the FixedUpdate of other <see cref="MonoBehaviour"/>s or evaluate collisions.
+        ///
+        /// Note: That values aren't re-read off of the RigidBody so all changes in <see cref="onStep"/> must make
+        ///       changes to the state parameters passed into the ExtrapolateState method.
+        /// </param>
+        /// <remarks>
+        /// Only drag and gravity values are read off of the provided <see cref="Rigidbody"/>. All other actor state is
+        /// provided through the method parameters.
+        /// </remarks>
+        public static void ExtrapolateState(
+            float delta,
+            Rigidbody rigidbody,
+            ref Vector3 position,
+            ref Quaternion rotation,
+            ref Vector3 linearVelocity,
+            ref Vector3 angularVelocity,
+            Action<float> onStep)
+        {
+            float drag = rigidbody.drag;
+            float angularDrag = rigidbody.angularDrag;
+            Vector3 gravity = rigidbody.useGravity ? UnityEngine.Physics.gravity : Vector3.zero;
+
+            while (delta > 0f)
+            {
+                float stepDelta = math.min(delta, Time.fixedDeltaTime);
+
+                StepState(stepDelta,
+                    drag,
+                    angularDrag,
+                    gravity,
+                    ref position,
+                    ref rotation,
+                    ref linearVelocity,
+                    ref angularVelocity);
+                onStep(stepDelta);
+
+                delta -= stepDelta;
+            }
+        }
+
+        private static void StepState(
+            float delta,
+            float drag,
+            float angularDrag,
+            Vector3 gravity,
+            ref Vector3 position,
+            ref Quaternion rotation,
+            ref Vector3 linearVelocity,
+            ref Vector3 angularVelocity)
+        {
+            linearVelocity += (gravity * delta);
+            linearVelocity *= (1f - (delta * drag));
+            angularVelocity *= (1f - (delta * angularDrag));
+
+            position += linearVelocity * delta;
+            rotation *= Quaternion.Euler(angularVelocity * delta);
+        }
+
+    }
+}

--- a/Scripts/Runtime/Physics/PhysicsUtil.cs.meta
+++ b/Scripts/Runtime/Physics/PhysicsUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e85d28dba4fc4bad9902f320654f4f22
+timeCreated: 1720231953


### PR DESCRIPTION
Add a method to extrapolate the state of a rigid body by a delta without needing to step Unity's physics system.

### What is the current behaviour?

None

### What is the new behaviour?

The method approximates the clean movement of a rigid body accounting for gravity, linear drag and angular drag. Does not account for collisions or any changes applied through the FixedUpdate of MonoBehaviours. However the latter can be accomplished by providing an onStep callback and calling the same logic that any FixedUpdate behaviours do.

Note: That values aren't re-read off of the RigidBody so all changes in onStep must make changes to the state parameters passed into the ExtrapolateState method.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
