### PR TITLE
Add CollectionExtension

### DIFF
--- a/Scripts/Runtime/Collections.meta
+++ b/Scripts/Runtime/Collections.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f67e499f76994e769f8f1fc39e6e0867
+timeCreated: 1722002393

--- a/Scripts/Runtime/Collections/CollectionExtension.cs
+++ b/Scripts/Runtime/Collections/CollectionExtension.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Anvil.Unity.Runtime.Collections
+{
+    /// <summary>
+    /// Extension methods for use with <see cref="ICollection{T}"/> instances.
+    /// Adds Unity specific extensions to supplement what's already provided by
+    /// <see cref="Anvil.CSharp.Collections.CollectionExtension"/>.
+    /// </summary>
+    public static class CollectionExtension
+    {
+        /// <summary>
+        /// Destroy all elements of a <see cref="ICollection{T}"/> and then clear the collection.
+        /// </summary>
+        /// <param name="collection">The <see cref="ICollection{T}"/> to operate on.</param>
+        /// <typeparam name="T">The element type</typeparam>
+        /// <remarks>
+        /// This method will only clear the <see cref="collection"/> if <see cref="ICollection{T}.IsReadOnly"/> is false.
+        /// </remarks>
+        public static void DestroyAllAndTryClear<T>(this ICollection<T> collection) where T : Object
+        {
+            foreach (T item in collection)
+            {
+                Component.Destroy(item);
+            }
+
+            if (!collection.IsReadOnly)
+            {
+                collection.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Destroy the <see cref="GameObject"/> hosting each element of a <see cref="ICollection{T}"/> and then clear
+        /// the collection.
+        /// </summary>
+        /// <param name="collection">The <see cref="ICollection{T}"/> to operate on.</param>
+        /// <typeparam name="T">The element type</typeparam>
+        /// <remarks>
+        /// This method will only clear the <see cref="collection"/> if <see cref="ICollection{T}.IsReadOnly"/> is false.
+        /// </remarks>
+        public static void DestroyAllGameObjectsAndTryClear<T>(this ICollection<T> collection) where T : Component
+        {
+            foreach (T item in collection)
+            {
+                Component.Destroy(item.gameObject);
+            }
+
+            if (!collection.IsReadOnly)
+            {
+                collection.Clear();
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Collections/CollectionExtension.cs.meta
+++ b/Scripts/Runtime/Collections/CollectionExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 195bb72c44ad413992509a5d637e4bed
+timeCreated: 1722002405


### PR DESCRIPTION
A Unity specific supplement to what's already provided by `CollectionExtensions` in `anvil-csharp-core`

### What is the current behaviour?
 - None

### What is the new behaviour?
`DestroyAllAndTryClear` - Destroy all `UnityEngine.Object` elements and try to clear the collection.
`DestroyAllGameObjectsAndTryClear` - Destroy the `GameObject` that hosts each `Component` element.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
