### PR TITLE
Removed `RotateAroundPoint` in favor of `Transform.RotateAround`

### DIFF
--- a/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
+++ b/Scripts/Editor/Tests/Core/Util/TransformExtensionTests.cs
@@ -12,9 +12,9 @@ namespace Anvil.Unity.Tests
         public static void ResetTest()
         {
             Assert.That(nameof(ResetTest), Is.EqualTo(nameof(TransformExtension.Reset) + "Test"));
-            
+
             Transform transform = new GameObject().transform;
-            
+
             transform.localPosition = new Vector3(RandomFloat(), RandomFloat(), RandomFloat());
             transform.localRotation = Quaternion.Euler(new Vector3(RandomFloat(), RandomFloat(), RandomFloat()));
             transform.localScale = new Vector3(RandomFloat(), RandomFloat(), RandomFloat());
@@ -23,10 +23,10 @@ namespace Anvil.Unity.Tests
             Assert.That(transform.localRotation, Is.EqualTo(Quaternion.identity));
             Assert.That(transform.localScale, Is.EqualTo(Vector3.one));
             return;
-            
+
             float RandomFloat() => Random.Range(-float.MaxValue, float.MaxValue);
         }
-        
+
         [Test]
         public static void SetLossyScaleTest()
         {
@@ -58,14 +58,14 @@ namespace Anvil.Unity.Tests
             GameObject.DestroyImmediate(parentGO);
             GameObject.DestroyImmediate(childGO);
         }
-        
+
         [Test]
         public static void ScaleAroundPointTest()
         {
             Assert.That(nameof(ScaleAroundPointTest), Is.EqualTo(nameof(TransformExtension.ScaleAroundPoint) + "Test"));
-            
+
             Transform transform = new GameObject().transform;
-            
+
             transform.localPosition = new Vector3(1f, 2f, 3f);
             transform.localScale = Vector3.one;
             transform.ScaleAroundPoint(2f, Vector3.zero);
@@ -89,27 +89,6 @@ namespace Anvil.Unity.Tests
             transform.ScaleAroundPoint(new Vector3(2f, 3f, 4f), new Vector3(5f, 5f, 5f));
             Assert.That(transform.localScale, Is.EqualTo(new Vector3(2f, 3f, 4f)));
             Assert.That(transform.localPosition, Is.EqualTo(new Vector3(-3f, -4f, -3f)));
-        }
-        
-        [Test]
-        public static void RotateAroundPointTest()
-        {
-            Assert.That(nameof(RotateAroundPointTest), Is.EqualTo(nameof(TransformExtension.RotateAroundPoint) + "Test"));
-            
-            Vector3EqualityComparer vector3Comparer = new (10e-7f);
-            Transform transform = new GameObject().transform;
-            
-            transform.localPosition = new Vector3(1f, 2f, 3f);
-            transform.localRotation = Quaternion.identity;
-            transform.RotateAroundPoint(Quaternion.AngleAxis(90f, Vector3.forward), Vector3.zero);
-            Assert.That(transform.localRotation.eulerAngles, Is.EqualTo(new Vector3(0f, 0f, 90f)));
-            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(-2f, 1f, 3f)).Using(vector3Comparer));
-            
-            transform.localPosition = new Vector3(1f, 2f, 3f);
-            transform.localRotation = Quaternion.identity;
-            transform.RotateAroundPoint(Quaternion.AngleAxis(90f, Vector3.forward), new Vector3(5f, 5f, 5f));
-            Assert.That(transform.localRotation.eulerAngles, Is.EqualTo(new Vector3(0f, 0f, 90f)));
-            Assert.That(transform.localPosition, Is.EqualTo(new Vector3(8f, 1f, 3f)).Using(vector3Comparer));
         }
     }
 }

--- a/Scripts/Runtime/Core/Util/TransformExtension.cs
+++ b/Scripts/Runtime/Core/Util/TransformExtension.cs
@@ -17,7 +17,7 @@ namespace Anvil.Unity.Core
             transform.localRotation = Quaternion.identity;
             transform.localScale = Vector3.one;
         }
-        
+
         /// <summary>
         /// Sets the world scale on a transform.
         /// </summary>
@@ -32,13 +32,13 @@ namespace Anvil.Unity.Core
                 scale.y / transform.lossyScale.y,
                 scale.z / transform.lossyScale.z);
         }
-        
+
         /// <inheritdoc cref="ScaleAroundPoint(UnityEngine.Transform,UnityEngine.Vector3,UnityEngine.Vector3)"/>
         public static void ScaleAroundPoint(this Transform transform, float scale, Vector3 worldSpacePivot)
         {
             transform.ScaleAroundPoint(Vector3.one * scale, worldSpacePivot);
         }
-        
+
         /// <summary>
         /// Scale the transform around a world-space pivot.
         /// </summary>
@@ -52,22 +52,6 @@ namespace Anvil.Unity.Core
             localScale.Scale(scale);
             transform.localScale = localScale;
             transform.localPosition += Vector3.Scale(pivotToPos, scale - Vector3.one);
-        }
-        
-        /// <summary>
-        /// Rotate the transform around a world-space pivot.
-        /// </summary>
-        /// <param name="transform">The transform to rotate.</param>
-        /// <param name="rotation">The rotation applied to the transform.</param>
-        /// <param name="worldSpacePivot">The pivot point around which the rotation is centered.</param>
-        public static void RotateAroundPoint(this Transform transform, Quaternion rotation, Vector3 worldSpacePivot)
-        {
-            Vector3 localSpacePivot = transform.InverseTransformPoint(worldSpacePivot);
-            Vector3 rotatedLocalSpacePivot = rotation * localSpacePivot;
-            Vector3 positionOffset = localSpacePivot - rotatedLocalSpacePivot;
-            
-            transform.localRotation = rotation * transform.localRotation;
-            transform.localPosition += positionOffset;
         }
     }
 }


### PR DESCRIPTION
I had previously added `RotateAroundPoint` because I thought `Transform.RotateAround` was deprecated, but that's only one weird overload. `Transform.RotateAround(point, axis, angle)` works perfectly fine, eliminating the need for this util.

### What is the current behaviour?

### What is the new behaviour?

### What issues does this resolve?

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes
   - Just change `transform.RotateAroundPoint(rotation, point)` to `transform.RotateAround(point, axis, angle)`
 - [ ] No
