### PR TITLE
AbstractUnityContent - Fix controller reference

### DIFF
--- a/Scripts/Runtime/Content/AbstractUnityContent.cs
+++ b/Scripts/Runtime/Content/AbstractUnityContent.cs
@@ -14,7 +14,11 @@ namespace Anvil.Unity.Content
         /// <summary>
         /// Gets/Sets the corresponding Controller as strongly typed version of <see cref="AbstractUnityContentController"/>
         /// </summary>
-        public new TController Controller { get; internal set; }
+        public new TController Controller
+        {
+            get => (TController)base.Controller;
+            internal set => base.Controller = value;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Strongly typed Controller property was hiding the generic property set underneath. Updated to match `AbstractUnityContentController.Content`'s implementation

### What is the current behaviour?

`AbstractUnityContent<TController>.Controller` will always be `null`

### What is the new behaviour?

`AbstractUnityContent<TController>.Controller` pulls the correct value from `AbstractUnityContent`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
