### PR TITLE
LoadResourceCommand - Remove complete listener on dispose

### DIFF
--- a/Scripts/Runtime/Asset/LoadResourceComand.cs
+++ b/Scripts/Runtime/Asset/LoadResourceComand.cs
@@ -48,6 +48,10 @@ namespace Anvil.Unity.Asset
 
         protected override void DisposeSelf()
         {
+            if (m_ResourceRequest != null)
+            {
+                m_ResourceRequest.completed -= ResourceRequest_Completed;
+            }
             m_ResourceRequest = null;
 
             base.DisposeSelf();


### PR DESCRIPTION
Prevents error when a load resource command is disposed while the resource load is in progress.

### What is the current behaviour?

Disposing a `LoadResourceCommand` while it is loading a resource causes a null exception when the loaded resource does complete since `m_ResrouceRequest` is now null.

### What is the new behaviour?

The complete listener is removed during disposal of the command.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
