### PR TITLE
Add GizmoUtils

### DIFF
--- a/Scripts/Runtime/Debugging/GizmoUtils.cs
+++ b/Scripts/Runtime/Debugging/GizmoUtils.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+using UnityEngine;
+
+namespace Anvil.Unity.Debugging
+{
+    /// <summary>
+    /// A collection of utility methods to supplement Unity's <see cref="Gizmos"/> tools
+    /// </summary>
+    public static class GizmoUtils
+    {
+        /// <summary>
+        /// Draw a Wireframe quad gizmo. Optionally showing the normal.
+        /// </summary>
+        /// <param name="position">The position of the center of the quad</param>
+        /// <param name="size">The total size of the quad</param>
+        /// <param name="showNormal">If true, a line is drawn along the normal</param>
+        [Conditional("UNITY_EDITOR")]
+        public static void DrawWireQuad(Vector3 position, Vector2 size, bool showNormal = false)
+        {
+            Vector3 halfSize = size * 0.5f;
+            Vector3 min = position - halfSize;
+            Vector3 max = position + halfSize;
+
+            Vector3 bottomLeft = min;
+            Vector3 topRight = max;
+            Vector3 bottomRight = new Vector3(max.x, min.y, min.z);
+            Vector3 topLeft = new Vector3(min.x, max.y, min.z);
+
+            Gizmos.DrawLine(bottomLeft, topLeft);
+            Gizmos.DrawLine(topLeft, topRight);
+            Gizmos.DrawLine(topRight, bottomRight);
+            Gizmos.DrawLine(bottomRight, bottomLeft);
+            Gizmos.DrawLine(topLeft, bottomRight);
+            Gizmos.DrawLine(topRight, bottomLeft);
+
+            if (showNormal)
+            {
+                Gizmos.DrawLine(position, position + (Vector3.forward * 0.25f));
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Debugging/GizmoUtils.cs.meta
+++ b/Scripts/Runtime/Debugging/GizmoUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f0923a4e04f94f4ba3c921fd14eea712
+timeCreated: 1746715960


### PR DESCRIPTION
A set of gizmo utilities that expand on Unity's offerings.

### What is the current behaviour?

### What is the new behaviour?

Add the ability to draw a wire quad gizmo with optional normal

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
