### PR TITLE
BoundsUtil - Fix StackOverflow

### DIFF
--- a/Scripts/Runtime/Core/Util/BoundsUtil.cs
+++ b/Scripts/Runtime/Core/Util/BoundsUtil.cs
@@ -36,7 +36,7 @@ namespace Anvil.Unity.Core
         /// <returns><see cref="Bounds"/> containing the points provided.</returns>
         public static Bounds CreateBoundingVolume(params Vector3[] points)
         {
-            return CreateBoundingVolume(points);
+            return CreateBoundingVolume((IList<Vector3>)points);
         }
 
         /// <inheritdoc cref="CreateBoundingVolume(UnityEngine.Vector3[])"/>


### PR DESCRIPTION
CreateBoundingVolume overload was calling itself rather than the CreateBoundingVolume(IList<Vector3>) implementation.

### What is the current behaviour?

Calling `CreateBoundingVolume()` and passing in a `Vector3[]` causes a stack overflow.

### What is the new behaviour?

Calling `CreateBoundingVolume()` behaves as expected.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
