### PR TITLE
QuitState - Fix double init

### DIFF
--- a/Scripts/Runtime/Core/Util/QuitState.cs
+++ b/Scripts/Runtime/Core/Util/QuitState.cs
@@ -54,6 +54,7 @@ namespace Anvil.Unity.Core
                 return;
             }
 
+            s_IsInitialized = true;
             Application.quitting += Application_quitting;
         }
 


### PR DESCRIPTION
In editor the quit state could be initialized multiple times causing double OnQuitting events to fire.

### What is the current behaviour?

`QuitState.OnQuitting` will fire twice on quit. If domain reload is disabled the event will fire an additional time for each consecutive time the project is run without re-compiling.

### What is the new behaviour?

`QuitState.OnQuitting` will fire a single time per play session.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
